### PR TITLE
Fix sample definition

### DIFF
--- a/azure-samples/pom.xml
+++ b/azure-samples/pom.xml
@@ -132,13 +132,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The `repackage` execution is inherited from the parent so there is no
need to duplicate it here.

@ZhijunZhao this related to our discussion in #159. If you generate an empty app on start.spring.io, you'll get the best practices that we are currently recommending.