### PR TITLE
Add azure-spring-boot-starter

### DIFF
--- a/.release-automation/config.json
+++ b/.release-automation/config.json
@@ -1,39 +1,39 @@
 {
-    "releaseVersion" : "0.1.9",
-    "moduleNames": [
-        "azure-spring-boot-parent",
-        "azure-spring-boot-bom",
-        "azure-support",
-        "azure-ad-integration-spring-boot-starter",
-        "azure-documentdb-spring-boot-starter",
-        "azure-storage-spring-boot-starter",
-        "azure-keyvault-secrets-spring-boot-starter",
-        "azure-mediaservices-spring-boot-starter",
-        "azure-servicebus-spring-boot-starter"
-    ],
-    "groupId": "com.microsoft.azure",
-    "targetFolder": "D:/Signed",
-    "toSignFolder": "//ADXInfra1/ToSign/",
-    "signedFilder": "//ADXInfra1/Signed",
-    "jenkins": {
-        "url": "http://azuresdkci.cloudapp.net/",
-        "username": "ZhijunZhao",
-        "signJar" : {
-            "Description": "Spring Boot Starters for Azure services",
-            "Keywords": "azure,starters"
-        }
-    },
-    "nexus": {
-        "username": "zhijzhao",
-        "stagingRepoDescription": "<promoteRequest><data><description>Spring Boot Starters for Azure Services</description></data></promoteRequest>",
-        "createRepoURL": "https://oss.sonatype.org/service/local/staging/profiles/534d15ee3800f4/start",
-        "closeRepoURL": "https://oss.sonatype.org/service/local/staging/profiles/534d15ee3800f4/finish",
-        "deployRepoURL": "https://oss.sonatype.org/service/local/staging/deployByRepositoryId",
-        "repoBaseURL": "https://oss.sonatype.org/service/local/staging/repository"
-    },
-    "passwords": {
-        "jenkins": "",
-        "gpg": "",
-        "nexus": ""
+  "releaseVersion": "0.1.9",
+  "moduleNames": [
+    "azure-spring-boot-parent",
+    "azure-spring-boot-bom",
+    "azure-support",
+    "azure-ad-integration-spring-boot-starter",
+    "azure-documentdb-spring-boot-starter",
+    "azure-storage-spring-boot-starter",
+    "azure-keyvault-secrets-spring-boot-starter",
+    "azure-mediaservices-spring-boot-starter",
+    "azure-servicebus-spring-boot-starter"
+  ],
+  "groupId": "com.microsoft.azure",
+  "targetFolder": "D:/Signed",
+  "toSignFolder": "//ADXInfra1/ToSign/",
+  "signedFilder": "//ADXInfra1/Signed",
+  "jenkins": {
+    "url": "http://azuresdkci.cloudapp.net/",
+    "username": "ZhijunZhao",
+    "signJar": {
+      "Description": "Spring Boot Starters for Azure services",
+      "Keywords": "azure,starters"
     }
+  },
+  "nexus": {
+    "username": "zhijzhao",
+    "stagingRepoDescription": "<promoteRequest><data><description>Spring Boot Starters for Azure Services</description></data></promoteRequest>",
+    "createRepoURL": "https://oss.sonatype.org/service/local/staging/profiles/534d15ee3800f4/start",
+    "closeRepoURL": "https://oss.sonatype.org/service/local/staging/profiles/534d15ee3800f4/finish",
+    "deployRepoURL": "https://oss.sonatype.org/service/local/staging/deployByRepositoryId",
+    "repoBaseURL": "https://oss.sonatype.org/service/local/staging/repository"
+  },
+  "passwords": {
+    "jenkins": "",
+    "gpg": "",
+    "nexus": ""
+  }
 }

--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -1,141 +1,146 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.microsoft.azure</groupId>
-	<artifactId>azure-spring-boot-bom</artifactId>
-	<version>0.1.9-SNAPSHOT</version>
-	<packaging>pom</packaging>
+    <groupId>com.microsoft.azure</groupId>
+    <artifactId>azure-spring-boot-bom</artifactId>
+    <version>0.1.9-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
-	<name>Azure Spring Boot BOM</name>
-	<description>BOM for Microsoft Azure Spring Boot Support</description>
-	<url>https://github.com/Microsoft/azure-spring-boot</url>
+    <name>Azure Spring Boot BOM</name>
+    <description>BOM for Microsoft Azure Spring Boot Support</description>
+    <url>https://github.com/Microsoft/azure-spring-boot</url>
 
-	<licenses>
-		<license>
-			<name>MIT</name>
-			<url>https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<id>ZhijunZhao</id>
-			<name>Zhijun Zhao</name>
-			<email>zhijzhao@microsoft.com</email>
-		</developer>
+    <developers>
+        <developer>
+            <id>ZhijunZhao</id>
+            <name>Zhijun Zhao</name>
+            <email>zhijzhao@microsoft.com</email>
+        </developer>
 
-		<developer>
-			<id>yungez</id>
-			<name>Yunge Zhu</name>
-			<email>yungez@microsoft.com</email>
-		</developer>
-	</developers>
+        <developer>
+            <id>yungez</id>
+            <name>Yunge Zhu</name>
+            <email>yungez@microsoft.com</email>
+        </developer>
+    </developers>
 
-	<organization>
-		<name>Microsoft</name>
-		<url>https://www.microsoft.com</url>
-	</organization>
+    <organization>
+        <name>Microsoft</name>
+        <url>https://www.microsoft.com</url>
+    </organization>
 
-	<scm>
-		<connection>scm:git:git://github.com/Microsoft/azure-spring-boot-starters.git</connection>
-		<developerConnection>scm:git:ssh://github.com:Microsoft/azure-spring-boot-starters.git</developerConnection>
-		<url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
-	</scm>
+    <scm>
+        <connection>scm:git:git://github.com/Microsoft/azure-spring-boot-starters.git</connection>
+        <developerConnection>scm:git:ssh://github.com:Microsoft/azure-spring-boot-starters.git</developerConnection>
+        <url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
+    </scm>
 
-	<properties>
-		<azure.adal4j.version>1.2.0</azure.adal4j.version>
-		<azure.documentdb.version>1.13.0</azure.documentdb.version>
-		<azure.storage.version>5.5.0</azure.storage.version>
-		<azure.keyvault.version>1.0.0</azure.keyvault.version>
-		<aad.adal4j.version>0.0.2</aad.adal4j.version>
-		<azure.media.version>0.9.7</azure.media.version>
-		<azure.servicebus.version>1.0.0</azure.servicebus.version>
-		<spring.data.documentdb.version>0.1.2</spring.data.documentdb.version>
-	</properties>
+    <properties>
+        <azure.adal4j.version>1.2.0</azure.adal4j.version>
+        <azure.documentdb.version>1.13.0</azure.documentdb.version>
+        <azure.storage.version>5.5.0</azure.storage.version>
+        <azure.keyvault.version>1.0.0</azure.keyvault.version>
+        <aad.adal4j.version>0.0.2</aad.adal4j.version>
+        <azure.media.version>0.9.7</azure.media.version>
+        <azure.servicebus.version>1.0.0</azure.servicebus.version>
+        <spring.data.documentdb.version>0.1.2</spring.data.documentdb.version>
+    </properties>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-ad-integration-spring-boot-starter</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-documentdb-spring-boot-starter</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-storage-spring-boot-starter</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-servicebus-spring-boot-starter</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-keyvault-secrets-spring-boot-starter</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-mediaservices-spring-boot-starter</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-support</artifactId>
-				<version>0.1.9-SNAPSHOT</version>
-			</dependency>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-ad-integration-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-documentdb-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-storage-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-servicebus-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-keyvault-secrets-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-mediaservices-spring-boot-starter</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-support</artifactId>
+                <version>0.1.9-SNAPSHOT</version>
+            </dependency>
 
-			<!-- Spring Data Cosmos DB library -->
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>spring-data-documentdb</artifactId>
-				<version>${spring.data.documentdb.version}</version>
-			</dependency>
-			<!-- Azure related libraries-->
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>adal4j</artifactId>
-				<version>${azure.adal4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-storage</artifactId>
-				<version>${azure.storage.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-documentdb</artifactId>
-				<version>${azure.documentdb.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-keyvault</artifactId>
-				<version>${azure.keyvault.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.aad</groupId>
-				<artifactId>adal4j</artifactId>
-				<version>${aad.adal4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-media</artifactId>
-				<version>${azure.media.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.microsoft.azure</groupId>
-				<artifactId>azure-servicebus</artifactId>
-				<version>${azure.servicebus.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+            <!-- Spring Data Cosmos DB library -->
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>spring-data-documentdb</artifactId>
+                <version>${spring.data.documentdb.version}</version>
+            </dependency>
+            <!-- Azure related libraries-->
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>adal4j</artifactId>
+                <version>${azure.adal4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-storage</artifactId>
+                <version>${azure.storage.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-documentdb</artifactId>
+                <version>${azure.documentdb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-keyvault</artifactId>
+                <version>${azure.keyvault.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.aad</groupId>
+                <artifactId>adal4j</artifactId>
+                <version>${aad.adal4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-media</artifactId>
+                <version>${azure.media.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-servicebus</artifactId>
+                <version>${azure.servicebus.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -205,6 +205,7 @@
 
     <modules>
         <module>../azure-support</module>
+		<module>../azure-starters/azure-spring-boot-starter</module>
         <module>../azure-starters/azure-ad-integration-spring-boot-starter</module>
         <module>../azure-starters/azure-documentdb-spring-boot-starter</module>
         <module>../azure-starters/azure-storage-spring-boot-starter</module>

--- a/azure-starters/azure-ad-integration-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-ad-integration-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-spring-boot-starter</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>

--- a/azure-starters/azure-ad-integration-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-ad-integration-spring-boot-starter/pom.xml
@@ -45,6 +45,10 @@
     </properties>
 
     <dependencies>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-spring-boot-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>

--- a/azure-starters/azure-documentdb-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-documentdb-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-spring-boot-starter</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>spring-data-documentdb</artifactId>

--- a/azure-starters/azure-documentdb-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-documentdb-spring-boot-starter/pom.xml
@@ -45,11 +45,10 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-support</artifactId>
-        </dependency>
-
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-spring-boot-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>spring-data-documentdb</artifactId>

--- a/azure-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-spring-boot-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault</artifactId>

--- a/azure-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-spring-boot-starter</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault</artifactId>

--- a/azure-starters/azure-keyvault-secrets-spring-boot-starter/src/main/java/com/microsoft/azure/keyvault/spring/boot/AzureKeyVaultCredential.java
+++ b/azure-starters/azure-keyvault-secrets-spring-boot-starter/src/main/java/com/microsoft/azure/keyvault/spring/boot/AzureKeyVaultCredential.java
@@ -12,7 +12,12 @@ import com.microsoft.aad.adal4j.ClientCredential;
 import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
 
 import java.net.MalformedURLException;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 
 public class AzureKeyVaultCredential extends KeyVaultCredentials {

--- a/azure-starters/azure-mediaservices-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-mediaservices-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-support</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-spring-boot-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-media</artifactId>

--- a/azure-starters/azure-mediaservices-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-mediaservices-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-spring-boot-starter</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-media</artifactId>

--- a/azure-starters/azure-servicebus-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-servicebus-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-support</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-spring-boot-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-servicebus</artifactId>

--- a/azure-starters/azure-servicebus-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-servicebus-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-spring-boot-starter</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-servicebus</artifactId>

--- a/azure-starters/azure-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-spring-boot-starter/pom.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.microsoft.azure</groupId>
-		<artifactId>azure-spring-boot-parent</artifactId>
-		<version>0.1.9-SNAPSHOT</version>
-		<relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
-	</parent>
+    <parent>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-spring-boot-parent</artifactId>
+        <version>0.1.9-SNAPSHOT</version>
+        <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
+    </parent>
 
-	<artifactId>azure-spring-boot-starter</artifactId>
-	<packaging>jar</packaging>
+    <artifactId>azure-spring-boot-starter</artifactId>
+    <packaging>jar</packaging>
 
-	<name>Azure Spring Boot Starter</name>
-	<description>Core starter, including auto-configuration support</description>
-	<url>https://github.com/Microsoft/azure-spring-boot</url>
+    <name>Azure Spring Boot Starter</name>
+    <description>Core starter, including auto-configuration support</description>
+    <url>https://github.com/Microsoft/azure-spring-boot</url>
 
-	<licenses>
-		<license>
-			<name>MIT</name>
-			<url>https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<id>rajadilipkolli</id>
-			<name>Raja Dilip Kolli</name>
-			<email>rajadileepkolli@outlook.com</email>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>rajadilipkolli</id>
+            <name>Raja Dilip Kolli</name>
+            <email>rajadileepkolli@outlook.com</email>
+        </developer>
+    </developers>
 
-	<scm>
-		<connection>scm:git:git://github.com/Microsoft/azure-spring-boot-starters.git</connection>
-		<developerConnection>scm:git:ssh://github.com:Microsoft/azure-spring-boot-starters.git</developerConnection>
-		<url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
-	</scm>
+    <scm>
+        <connection>scm:git:git://github.com/Microsoft/azure-spring-boot-starters.git</connection>
+        <developerConnection>scm:git:ssh://github.com:Microsoft/azure-spring-boot-starters.git</developerConnection>
+        <url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
+    </scm>
 
-	<properties>
-		<project.rootdir>${project.basedir}/../..</project.rootdir>
-	</properties>
+    <properties>
+        <project.rootdir>${project.basedir}/../..</project.rootdir>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-support</artifactId>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-support</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/azure-starters/azure-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-spring-boot-starter/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.microsoft.azure</groupId>
+		<artifactId>azure-spring-boot-parent</artifactId>
+		<version>0.1.9-SNAPSHOT</version>
+		<relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
+	</parent>
+
+	<artifactId>azure-spring-boot-starter</artifactId>
+	<packaging>jar</packaging>
+
+	<name>Azure Spring Boot Starter</name>
+	<description>Core starter, including auto-configuration support</description>
+	<url>https://github.com/Microsoft/azure-spring-boot</url>
+
+	<licenses>
+		<license>
+			<name>MIT</name>
+			<url>https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>rajadilipkolli</id>
+			<name>Raja Dilip Kolli</name>
+			<email>rajadileepkolli@outlook.com</email>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git://github.com/Microsoft/azure-spring-boot-starters.git</connection>
+		<developerConnection>scm:git:ssh://github.com:Microsoft/azure-spring-boot-starters.git</developerConnection>
+		<url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
+	</scm>
+
+	<properties>
+		<project.rootdir>${project.basedir}/../..</project.rootdir>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-support</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/azure-starters/azure-storage-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-storage-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-support</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>azure-spring-boot-starter</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>

--- a/azure-starters/azure-storage-spring-boot-starter/pom.xml
+++ b/azure-starters/azure-storage-spring-boot-starter/pom.xml
@@ -45,10 +45,10 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>azure-spring-boot-starter</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>

--- a/azure-starters/pom.xml
+++ b/azure-starters/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.microsoft.azure</groupId>
-		<artifactId>azure-spring-boot-parent</artifactId>
-		<version>0.1.9-SNAPSHOT</version>
-		<relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
-	</parent>
+    <parent>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-spring-boot-parent</artifactId>
+        <version>0.1.9-SNAPSHOT</version>
+        <relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
+    </parent>
 
-	<artifactId>azure-starters</artifactId>
-	<packaging>pom</packaging>
+    <artifactId>azure-starters</artifactId>
+    <packaging>pom</packaging>
 
-	<name>Azure Spring Boot Starers</name>
-	<description>Spring Boot Starters for Azure</description>
-	<url>https://github.com/Microsoft/azure-spring-boot</url>
+    <name>Azure Spring Boot Starers</name>
+    <description>Spring Boot Starters for Azure</description>
+    <url>https://github.com/Microsoft/azure-spring-boot</url>
 
-	<modules>
-		<module>azure-ad-integration-spring-boot-starter</module>
-		<module>azure-documentdb-spring-boot-starter</module>
-		<module>azure-keyvault-secrets-spring-boot-starter</module>
-		<module>azure-mediaservices-spring-boot-starter</module>
-		<module>azure-servicebus-spring-boot-starter</module>
-		<module>azure-storage-spring-boot-starter</module>
-	</modules>
+    <modules>
+        <module>azure-spring-boot-starter</module>
+        <module>azure-ad-integration-spring-boot-starter</module>
+        <module>azure-documentdb-spring-boot-starter</module>
+        <module>azure-keyvault-secrets-spring-boot-starter</module>
+        <module>azure-mediaservices-spring-boot-starter</module>
+        <module>azure-servicebus-spring-boot-starter</module>
+        <module>azure-storage-spring-boot-starter</module>
+    </modules>
 
 </project>

--- a/azure-support/src/test/java/com/microsoft/azure/spring/boot/autoconfigure/documentdb/DocumentDbRepositoriesAutoConfigurationUnitTest.java
+++ b/azure-support/src/test/java/com/microsoft/azure/spring/boot/autoconfigure/documentdb/DocumentDbRepositoriesAutoConfigurationUnitTest.java
@@ -6,9 +6,9 @@
 
 package com.microsoft.azure.spring.boot.autoconfigure.documentdb;
 
+import com.microsoft.azure.documentdb.DocumentClient;
 import com.microsoft.azure.spring.boot.autoconfigure.documentdb.domain.Person;
 import com.microsoft.azure.spring.boot.autoconfigure.documentdb.domain.PersonRepository;
-import com.microsoft.azure.documentdb.DocumentClient;
 import com.microsoft.azure.spring.data.documentdb.core.DocumentDbTemplate;
 import com.microsoft.azure.spring.data.documentdb.repository.config.EnableDocumentDbRepositories;
 import org.junit.After;

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 
     <dependencyManagement>
         <dependencies>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-ad-integration-spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
     </scm>
 
     <modules>
-		<module>azure-spring-boot-bom</module>
+        <module>azure-spring-boot-bom</module>
         <module>azure-spring-boot-parent</module>
         <module>azure-samples</module>
-		<module>azure-support</module>
-		<module>azure-starters</module>
+        <module>azure-support</module>
+        <module>azure-starters</module>
     </modules>
-	
+
 </project>


### PR DESCRIPTION
This commit adds the core Azure starter that other starters rely on. It
mirrors the infrastructure in place in Spring Boot.