### PR TITLE
Restructure build

### DIFF
--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.microsoft.azure</groupId>
+	<artifactId>azure-spring-boot-bom</artifactId>
+	<version>0.1.9-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<name>Azure Spring Boot BOM</name>
+	<description>BOM for Microsoft Azure Spring Boot Support</description>
+	<url>https://github.com/Microsoft/azure-spring-boot</url>
+
+	<licenses>
+		<license>
+			<name>MIT</name>
+			<url>https://github.com/Microsoft/azure-spring-boot/blob/master/LICENSE</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>ZhijunZhao</id>
+			<name>Zhijun Zhao</name>
+			<email>zhijzhao@microsoft.com</email>
+		</developer>
+
+		<developer>
+			<id>yungez</id>
+			<name>Yunge Zhu</name>
+			<email>yungez@microsoft.com</email>
+		</developer>
+	</developers>
+
+	<organization>
+		<name>Microsoft</name>
+		<url>https://www.microsoft.com</url>
+	</organization>
+
+	<scm>
+		<connection>scm:git:git://github.com/Microsoft/azure-spring-boot-starters.git</connection>
+		<developerConnection>scm:git:ssh://github.com:Microsoft/azure-spring-boot-starters.git</developerConnection>
+		<url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
+	</scm>
+
+	<properties>
+		<azure.adal4j.version>1.2.0</azure.adal4j.version>
+		<azure.documentdb.version>1.13.0</azure.documentdb.version>
+		<azure.storage.version>5.5.0</azure.storage.version>
+		<azure.keyvault.version>1.0.0</azure.keyvault.version>
+		<aad.adal4j.version>0.0.2</aad.adal4j.version>
+		<azure.media.version>0.9.7</azure.media.version>
+		<azure.servicebus.version>1.0.0</azure.servicebus.version>
+		<spring.data.documentdb.version>0.1.2</spring.data.documentdb.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-ad-integration-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-documentdb-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-storage-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-servicebus-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-keyvault-secrets-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-mediaservices-spring-boot-starter</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-support</artifactId>
+				<version>0.1.9-SNAPSHOT</version>
+			</dependency>
+
+			<!-- Spring Data Cosmos DB library -->
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>spring-data-documentdb</artifactId>
+				<version>${spring.data.documentdb.version}</version>
+			</dependency>
+			<!-- Azure related libraries-->
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>adal4j</artifactId>
+				<version>${azure.adal4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-storage</artifactId>
+				<version>${azure.storage.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-documentdb</artifactId>
+				<version>${azure.documentdb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-keyvault</artifactId>
+				<version>${azure.keyvault.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.aad</groupId>
+				<artifactId>adal4j</artifactId>
+				<version>${aad.adal4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-media</artifactId>
+				<version>${azure.media.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.microsoft.azure</groupId>
+				<artifactId>azure-servicebus</artifactId>
+				<version>${azure.servicebus.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+</project>

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -8,7 +8,7 @@
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-bom</artifactId>
         <version>0.1.9-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../azure-spring-boot-bom/pom.xml</relativePath>
     </parent>
 
     <artifactId>azure-spring-boot-parent</artifactId>
@@ -202,14 +202,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <modules>
-        <module>../azure-support</module>
-        <module>../azure-starters/azure-ad-integration-spring-boot-starter</module>
-        <module>../azure-starters/azure-documentdb-spring-boot-starter</module>
-        <module>../azure-starters/azure-storage-spring-boot-starter</module>
-        <module>../azure-starters/azure-servicebus-spring-boot-starter</module>
-        <module>../azure-starters/azure-mediaservices-spring-boot-starter</module>
-        <module>../azure-starters/azure-keyvault-secrets-spring-boot-starter</module>
-    </modules>
 </project>

--- a/azure-starters/pom.xml
+++ b/azure-starters/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.microsoft.azure</groupId>
+		<artifactId>azure-spring-boot-parent</artifactId>
+		<version>0.1.9-SNAPSHOT</version>
+		<relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
+	</parent>
+
+	<artifactId>azure-starters</artifactId>
+	<packaging>pom</packaging>
+
+	<name>Azure Spring Boot Starers</name>
+	<description>Spring Boot Starters for Azure</description>
+	<url>https://github.com/Microsoft/azure-spring-boot</url>
+
+	<modules>
+		<module>azure-ad-integration-spring-boot-starter</module>
+		<module>azure-documentdb-spring-boot-starter</module>
+		<module>azure-keyvault-secrets-spring-boot-starter</module>
+		<module>azure-mediaservices-spring-boot-starter</module>
+		<module>azure-servicebus-spring-boot-starter</module>
+		<module>azure-storage-spring-boot-starter</module>
+	</modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-spring-boot-bom</artifactId>
+    <artifactId>azure-spring-boot-build</artifactId>
     <version>0.1.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Azure Spring Boot BOM</name>
-    <description>BOM for Microsoft Azure Spring Boot Support</description>
+    <name>Azure Spring Boot Build</name>
+    <description>Build for Microsoft Azure Spring Boot Support</description>
     <url>https://github.com/Microsoft/azure-spring-boot</url>
 
     <licenses>
@@ -45,102 +45,12 @@
         <url>https://github.com/Microsoft/azure-spring-boot/tree/master</url>
     </scm>
 
-    <properties>
-        <azure.adal4j.version>1.2.0</azure.adal4j.version>
-        <azure.documentdb.version>1.13.0</azure.documentdb.version>
-        <azure.storage.version>5.5.0</azure.storage.version>
-        <azure.keyvault.version>1.0.0</azure.keyvault.version>
-        <aad.adal4j.version>0.0.2</aad.adal4j.version>
-        <azure.media.version>0.9.7</azure.media.version>
-        <azure.servicebus.version>1.0.0</azure.servicebus.version>
-        <spring.data.documentdb.version>0.1.2</spring.data.documentdb.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-ad-integration-spring-boot-starter</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-documentdb-spring-boot-starter</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-storage-spring-boot-starter</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-servicebus-spring-boot-starter</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-keyvault-secrets-spring-boot-starter</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-mediaservices-spring-boot-starter</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-support</artifactId>
-                <version>0.1.9-SNAPSHOT</version>
-            </dependency>
-
-            <!-- Spring Data Cosmos DB library -->
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>spring-data-documentdb</artifactId>
-                <version>${spring.data.documentdb.version}</version>
-            </dependency>
-            <!-- Azure related libraries-->
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>adal4j</artifactId>
-                <version>${azure.adal4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-storage</artifactId>
-                <version>${azure.storage.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-documentdb</artifactId>
-                <version>${azure.documentdb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-keyvault</artifactId>
-                <version>${azure.keyvault.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.aad</groupId>
-                <artifactId>adal4j</artifactId>
-                <version>${aad.adal4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-media</artifactId>
-                <version>${azure.media.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-servicebus</artifactId>
-                <version>${azure.servicebus.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <modules>
+		<module>azure-spring-boot-bom</module>
         <module>azure-spring-boot-parent</module>
         <module>azure-samples</module>
+		<module>azure-support</module>
+		<module>azure-starters</module>
     </modules>
+	
 </project>


### PR DESCRIPTION
This commit restructure the build so that the BOM becomes a module on
its own rather than being the root of the repository.

This commit also puts the `modules` section where they belong.