### PR TITLE
Remove unused dependency

### DIFF
--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -40,12 +40,6 @@
             <artifactId>json</artifactId>
         </dependency>
 
-        <!--Keyvault-->
-        <dependency>
-            <groupId>com.microsoft.rest</groupId>
-            <artifactId>client-runtime</artifactId>
-        </dependency>
-
         <!--Azure active directory-->
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
The auto-configuration module should define only optional dependencies
as much as possible so that the starter brings the necessary bits to
enable a particular feature.

This dependency should not be compiled scope. I've removed it to test
where it is actually used and nothing breaks. Please review and either
restore it with optional scope, adding it with compile scope in the
relevant starter.