### PR TITLE
Remove use of starter in the autoconfigure module

### DIFF
--- a/azure-spring-boot-starters/azure-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-spring-boot-starter/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-spring-boot</artifactId>
         </dependency>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -21,12 +21,13 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
+            <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!--Cloud Foundry support-->
@@ -115,6 +116,13 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Annotation processor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
The auto-configuration module should not use starter as this is
something that's not necessary in the scope of that module. That helps
narrowing down what is actually necessary for the auto-configuration to
work.