### PR TITLE
update version to 0.2.1

### DIFF
--- a/.release-automation/config.json
+++ b/.release-automation/config.json
@@ -1,5 +1,5 @@
 {
-  "releaseVersion": "0.2.0",
+  "releaseVersion": "0.2.1",
   "moduleNames": [
     "azure-spring-boot-parent",
     "azure-spring-boot-bom",

--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-spring-boot-bom</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1</version>
     <packaging>pom</packaging>
 
     <name>Azure Spring Boot BOM</name>
@@ -52,7 +52,7 @@
         <azure.keyvault.version>1.0.0</azure.keyvault.version>
         <azure.media.version>0.9.7</azure.media.version>
         <azure.servicebus.version>1.0.0</azure.servicebus.version>
-        <spring.data.documentdb.version>0.1.2</spring.data.documentdb.version>
+        <spring.data.documentdb.version>0.1.3</spring.data.documentdb.version>
         <microsoft.client-runtime.version>1.0.0</microsoft.client-runtime.version>
     </properties>
 
@@ -61,42 +61,42 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.1</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-active-directory-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-documentdb-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.1</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-storage-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-servicebus-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-keyvault-secrets-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-mediaservices-spring-boot-starter</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-spring-boot</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.1</version>
             </dependency>
 
             <!-- Spring Data Cosmos DB library -->

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-bom</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../azure-spring-boot-bom/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-samples/pom.xml
+++ b/azure-spring-boot-samples/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-spring-boot-bom</artifactId>
-                <version>0.2.0-SNAPSHOT</version>
+                <version>0.2.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/azure-spring-boot-starters/azure-active-directory-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-active-directory-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-documentdb-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-documentdb-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-mediaservices-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-mediaservices-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-servicebus-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-servicebus-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-storage-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-storage-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/pom.xml
+++ b/azure-spring-boot-starters/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1</version>
         <relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/documentdb/DocumentDBAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/documentdb/DocumentDBAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.data.annotation.Persistent;
 @EnableConfigurationProperties(DocumentDBProperties.class)
 public class DocumentDBAutoConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentDBAutoConfiguration.class);
-    private static final String USER_AGENT_SUFFIX = "spring-boot-starter/0.2.0-SNAPSHOT";
+    private static final String USER_AGENT_SUFFIX = "spring-boot-starter/0.2.1";
 
     private final DocumentDBProperties properties;
     private final ConnectionPolicy connectionPolicy;

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/documentdb/PropertySettingUtil.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/documentdb/PropertySettingUtil.java
@@ -25,7 +25,7 @@ public class PropertySettingUtil {
     public static final int MAX_POOL_SIZE = 1;
     public static final int IDLE_CONNECTION_TIMEOUT = 2;
     public static final String USER_AGENT_SUFFIX = "suffix";
-    public static final String DEFAULT_USER_AGENT_SUFFIX = "spring-boot-starter/0.2.0-SNAPSHOT";
+    public static final String DEFAULT_USER_AGENT_SUFFIX = "spring-boot-starter/0.2.1";
     public static final int RETRY_OPTIONS_MAX_RETRY_ATTEMPTS_ON_THROTTLED_REQUESTS = 5;
     public static final int RETRY_OPTIONS_MAX_RETRY_WAIT_TIME_IN_SECONDS = 6;
     public static final boolean ENABLE_ENDPOINT_DISCOVERY = false;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-spring-boot-build</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1</version>
     <packaging>pom</packaging>
 
     <name>Azure Spring Boot Build</name>


### PR DESCRIPTION
azure-spring-boot-bom 0.2.1 will contain:
1. azure-documentdb-spring-boot-starter, 0.2.1, depends on spring-data-documentdb 0.1.3
2. azure-active-directory-spring-boot-starter, 0.2.0
3. azure-storage-spring-boot-starter, 0.2.0
4. azure-servicebus-spring-boot-starter, 0.2.0
5. azure-keyvault-secrets-spring-boot-starter, 0.2.0
6. azure-mediaservices-spring-boot-starter, 0.2.0
