### PR TITLE
Add json dependency for azure spring boot samples.

### DIFF
--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -30,6 +30,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20171018</version>
+        </dependency>
+
         <!--Cloud Foundry support-->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
* Some samples like mediaservices, servicebus need json.

Signed-off-by: Pan Li <panli@microsoft.com>

## Summary
<!--Describe the change berifly-->

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature
- Bug fixing

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - active directory spring boot starter
  - documentdb spring boot starter
  - key vault spring boot starter
  - media services spring boot starter
  - service bus spring boot starter
  - storage spring boot starter

## Additional Information