### PR TITLE
add missing dependencies which are required when using azure-spring-boot alone

### DIFF
--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -80,6 +80,16 @@
                 <artifactId>json</artifactId>
                 <version>20171018</version>
             </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.17</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -26,6 +26,16 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <spring.boot.version>2.0.0.RELEASE</spring.boot.version>
+        <findbugs.annotations.version>2.0.1</findbugs.annotations.version>
+        <nimbus.jose.jwt.version>4.39.2</nimbus.jose.jwt.version>
+        <mockito.core.version>2.8.9</mockito.core.version>
+        <powermock.junit4.version>1.7.0</powermock.junit4.version>
+        <powermock.api.mockito2.version>1.7.0</powermock.api.mockito2.version>
+        <org.json.version>20171018</org.json.version>
+        <commons.logging.version>1.2</commons.logging.version>
+        <snakeyaml.version>1.17</snakeyaml.version>
     </properties>
 
     <profiles>
@@ -46,49 +56,49 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.0.0.RELEASE</version>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>annotations</artifactId>
-                <version>2.0.1</version>
+                <version>${findbugs.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>4.39.2</version>
+                <version>${nimbus.jose.jwt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.8.9</version>
+                <version>${mockito.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-module-junit4</artifactId>
-                <version>1.7.0</version>
+                <version>${powermock.junit4.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-mockito2</artifactId>
-                <version>1.7.0</version>
+                <version>${powermock.api.mockito2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20171018</version>
+                <version>${org.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
+                <version>${commons.logging.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.17</version>
+                <version>${snakeyaml.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -44,6 +44,14 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
 
         <!--Azure active directory-->
         <dependency>


### PR DESCRIPTION
## Summary
Spring Boot application cannot start with azure-spring-boot dependency only.
These added dependencies will be provided by spring boot starters if any of spring boot starter is imported.

## Issue Type
- Bug fixing

## Starter Names
  - azure spring boot 

## Additional Information
refs #307 