### PR TITLE
Support for azure storage using user provided services

### DIFF
--- a/azure-spring-boot-samples/azure-cloud-foundry-service-sample/README.md
+++ b/azure-spring-boot-samples/azure-cloud-foundry-service-sample/README.md
@@ -1,5 +1,5 @@
 This sample project demonstrates how to consume azure services exposed through the Microsoft Azure Service Broker for
-applications running in Cloud Foundry.
+applications running in Cloud Foundry or by consuming the service configuration through a user provided service.
  
 # Pre-reqs:  Create required service instances in Cloud Foundry
 Before you can create any service instances, you'll need to create a resource group on Azure.  Then you'll reference that
@@ -104,7 +104,72 @@ Now you can create the new service
 cf create-service azure-documentdb standard azure-documentdb-service -c ./azure-documentdb.json
 ```
 
+# User Provided Service
 
+It is also possible to use a user provided service to get the credentials used to connect to the service, and make use of the start to automatically bind just as if with an azure broker service.
+
+This allows applications to share the same storage across pcf foundations, for example.
+
+The Pre Reqs section don't really apply for user provided services, however, you may create a service using the Microsoft Azure Service Broker and take the credentials from that service to create other user provided services which will connect to the same storage (see example further ahead).
+
+To create a user provided service compatible with the starter, you first need to create a json with the service credentials (ex. azure-service-credentials.json)
+```
+{
+    "azure-service-broker-name":"azure-documentdb",
+    "documentdb_host_endpoint": "https://docdb-account.documents.azure.com:443/",                                       
+    "documentdb_master_key": "XXPSWDXXX==",
+    "documentdb_database_id": "databasename",                                                                             
+    "documentdb_database_link": "dbs/XXXXX==/"                                                                         
+}
+```
+You basically create the credentials block the same way as the credentials block created by the Microsoft Azure Service Broker (see example further ahead), and add the attribute `azure-service-broker-name` with the name of the broker responsible for the service (in this case, "azure-documentdb").
+
+You can then create the service
+
+```
+cf create-user-provided-service user-provided-azure-service -p ./azure-service-credentials.json
+```
+
+It is worth noticing that the Microsoft Azure Service Broker doesn't actually need to be available for this to work, but the broker names should be the same as the ones the Service Broker provide (as shown at the beginning).
+
+## Example Service Creation with a Microsoft Azure Service Broker service
+
+Taking as an example the documentdb service created in the previous section, you may inspect the environment of the application to see which credentials the service has
+```
+System-Provided:
+{
+ "VCAP_SERVICES": {
+  "azure-documentdb": [
+   {
+    "credentials": {
+     "documentdb_database_id": "databasename",
+     "documentdb_database_link": "dbs/XXXXX==/",
+     "documentdb_host_endpoint": "https://docdb-account.documents.azure.com:443/",
+     "documentdb_master_key": "XXPSWDXXX"
+    },
+    "label": "azure-documentdb",
+    "name": "azure-documentdb-service",
+    "plan": "standard",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [],
+    "volume_mounts": []
+   }
+  ]
+ }
+}
+```
+The credentials attribute can be used to create the json file for the user provided service.
+```
+{
+    "azure-service-broker-name":"azure-documentdb",
+    "documentdb_host_endpoint": "https://docdb-account.documents.azure.com:443/",                                       
+    "documentdb_master_key": "XXPSWDXXX==",
+    "documentdb_database_id": "databasename",                                                                             
+    "documentdb_database_link": "dbs/XXXXX==/"                                                                         
+}
+```
+Which can then be used to create user provided services in any space or foundation, and sharing the same storage.
 
 # To push sample application to PCF
 Login to your PCF environment and run "cf push" from the cloudfoundry/azure-cloud-foundry-service-sample folder.

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/cloundfoundry/environment/AzureCloudFoundryServiceApplicationTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/cloundfoundry/environment/AzureCloudFoundryServiceApplicationTest.java
@@ -113,4 +113,43 @@ public class AzureCloudFoundryServiceApplicationTest {
         }
     }
 
+    @Test
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
+    public void testVcapUserProvidedService() {
+        final Resource resource = new ClassPathResource("/vcap3.json");
+        final String content;
+        try {
+            content = new String(
+                    Files.readAllBytes(Paths.get(resource.getURI())));
+            final VcapResult result = parser.parse(content);
+            final VcapPojo[] pojos = result.getPojos();
+            assertNotNull(pojos);
+            assertEquals(1, pojos.length);
+            final VcapPojo pojo = pojos[0];
+
+            LOG.debug("pojo = " + pojo);
+            assertEquals(4, pojo.getCredentials().size());
+            assertEquals(0, pojo.getTags().length);
+            assertEquals(0, pojo.getVolumeMounts().length);
+            assertEquals("user-provided", pojo.getLabel());
+            assertNull(pojo.getProvider());
+            assertEquals("azure-documentdb", pojo.getServiceBrokerName());
+            assertEquals("mydocumentdb", pojo.getServiceInstanceName());
+            assertEquals("standard", pojo.getServicePlan());
+            assertNull(pojo.getSyslogDrainUrl());
+
+            assertEquals("docdb123mj",
+                    pojo.getCredentials().get("documentdb_database_id"));
+            assertEquals("dbs/ZFxCAA==/",
+                    pojo.getCredentials().get("documentdb_database_link"));
+            assertEquals("https://hostname:443/",
+                    pojo.getCredentials().get("documentdb_host_endpoint"));
+            assertEquals(
+                    "3becR7JFnWamMvGwWYWWTV4WpeNhN8tOzJ74yjAxPKDpx65q2lYz60jt8WXU6HrIKrAIwhs0Hglf0123456789==",
+                    pojo.getCredentials().get("documentdb_master_key"));
+        } catch (IOException e) {
+            LOG.error("Error reading json file", e);
+        }
+    }
+
 }

--- a/azure-spring-boot/src/test/resources/vcap3.json
+++ b/azure-spring-boot/src/test/resources/vcap3.json
@@ -1,0 +1,20 @@
+{
+  "user-provided": [
+    {
+      "credentials": {
+        "azure-service-broker-name": "azure-documentdb",
+        "azure-service-plan": "standard",
+        "documentdb_database_id": "docdb123mj",
+        "documentdb_database_link": "dbs/ZFxCAA==/",
+        "documentdb_host_endpoint": "https://hostname:443/",
+        "documentdb_master_key": "3becR7JFnWamMvGwWYWWTV4WpeNhN8tOzJ74yjAxPKDpx65q2lYz60jt8WXU6HrIKrAIwhs0Hglf0123456789=="
+      },
+      "label": "user-provided",
+      "name": "mydocumentdb",
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ]
+}
+ 


### PR DESCRIPTION
## Summary
This change allows the use of the starters with pcf user provided services containing credentials for azure service types. Documentation was added.

It will basically allow same apps to share the same azure storage cross pcf foundations (the Microsoft Azure Service Broker creates new storages, but it doesn't allow to re-use an existing storage), which can be used in some failsafe strategies.

## Issue Type
- New Feature

## Starter Names
  - active directory spring boot starter
  - documentdb spring boot starter
  - key vault spring boot starter
  - media services spring boot starter
  - service bus spring boot starter
  - storage spring boot starter

## Additional Information