### PR TITLE
Update README.md

### DIFF
--- a/azure-spring-boot-samples/azure-keyvault-secrets-spring-boot-sample/README.md
+++ b/azure-spring-boot-samples/azure-keyvault-secrets-spring-boot-sample/README.md
@@ -28,8 +28,8 @@ az keyvault create --name <your_keyvault_name>            \
                    --enabled-for-disk-encryption true     \
                    --enabled-for-template-deployment true \
                    --sku standard
-az keyvault set-policy --name <your_keyvault_name> \
-                       --secret-permission all     \
+az keyvault set-policy --name <your_keyvault_name>   \
+                       --secret-permission get list  \
                        --spn <your_sp_id_create_in_step1>
 ```
 Save the displayed Key Vault uri for later use.


### PR DESCRIPTION
The output when running `az keyvault set-policy -h` (to get the help documentation) states the following for the `--secret-permissions` argument: "Space-separated list of secret permissions to assign.  Allowed values: backup, delete, get, list, purge, recover, restore, set." 

There no longer appears to be support for `all`, so I am proposing to replace this with `get list` to support the ability to `get` and `list` the keyvault secret key / values.