### PR TITLE
Lombok dependency should only use "provided" scope.

### DIFF
--- a/azure-spring-boot-samples/azure-active-directory-spring-boot-sample/pom.xml
+++ b/azure-spring-boot-samples/azure-active-directory-spring-boot-sample/pom.xml
@@ -30,6 +30,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
According to the official Lombok documentation
(https://projectlombok.org/mavenrepo/), the Lombok library should be
referenced as "provided" in scope. This ensures that downstream projects that
include this Spring Boot Starter project do not pull in Lombok unnecessarily.

This fixes #330

-=david=-

## Summary
<!--Describe the change berifly-->

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature
- Bug fixing

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - active directory spring boot starter
  - documentdb spring boot starter
  - key vault spring boot starter
  - media services spring boot starter
  - service bus spring boot starter
  - storage spring boot starter

## Additional Information