### PR TITLE
move graph APIs into separate class in order to be reused

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
@@ -64,8 +64,10 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
 
                 if (principal == null || graphApiToken == null || graphApiToken.isEmpty()) {
                     principal = new UserPrincipal(idToken, serviceEndpoints);
-                    graphApiToken =
-                            client.acquireTokenForGraphApi(idToken, principal.getClaim().toString()).getAccessToken();
+
+                    final String tenantId = principal.getClaim().toString();
+                    graphApiToken = client.acquireTokenForGraphApi(idToken, tenantId).getAccessToken();
+
                     principal.setUserGroups(client.getGroups(graphApiToken));
 
                     request.getSession().setAttribute(CURRENT_USER_PRINCIPAL, principal);

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
@@ -5,10 +5,6 @@
  */
 package com.microsoft.azure.spring.autoconfigure.aad;
 
-import com.microsoft.aad.adal4j.AuthenticationContext;
-import com.microsoft.aad.adal4j.AuthenticationResult;
-import com.microsoft.aad.adal4j.ClientCredential;
-import com.microsoft.aad.adal4j.UserAssertion;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.proc.BadJOSEException;
 import org.slf4j.Logger;
@@ -27,9 +23,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.text.ParseException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 public class AADAuthenticationFilter extends OncePerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(AADAuthenticationFilter.class);
@@ -47,38 +40,6 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
                                    ServiceEndpointsProperties serviceEndpointsProp) {
         this.aadAuthFilterProp = aadAuthFilterProp;
         this.serviceEndpointsProp = serviceEndpointsProp;
-    }
-
-    private AuthenticationResult acquireTokenForGraphApi(
-            String idToken,
-            String tenantId,
-            ServiceEndpoints serviceEndpoints)
-            throws MalformedURLException, ServiceUnavailableException, InterruptedException, ExecutionException {
-
-        final ClientCredential credential = new ClientCredential(
-                aadAuthFilterProp.getClientId(), aadAuthFilterProp.getClientSecret());
-        final UserAssertion assertion = new UserAssertion(idToken);
-
-        AuthenticationResult result = null;
-        ExecutorService service = null;
-        try {
-            service = Executors.newFixedThreadPool(1);
-            final AuthenticationContext context = new AuthenticationContext(
-                    serviceEndpoints.getAadSigninUri() + tenantId + "/", true, service);
-            final Future<AuthenticationResult> future = context
-                    .acquireToken(serviceEndpoints.getAadGraphApiUri(), assertion, credential, null);
-            result = future.get();
-        } finally {
-            if (service != null) {
-                service.shutdown();
-            }
-        }
-
-        if (result == null) {
-            throw new ServiceUnavailableException(
-                    "unable to acquire on-behalf-of token for client " + aadAuthFilterProp.getClientId());
-        }
-        return result;
     }
 
     @Override
@@ -99,21 +60,20 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
 
                 final ServiceEndpoints serviceEndpoints =
                         serviceEndpointsProp.getServiceEndpoints(aadAuthFilterProp.getEnvironment());
+                final AzureADGraphClient client = new AzureADGraphClient(aadAuthFilterProp, serviceEndpointsProp);
 
                 if (principal == null || graphApiToken == null || graphApiToken.isEmpty()) {
                     principal = new UserPrincipal(idToken, serviceEndpoints);
-                    graphApiToken = acquireTokenForGraphApi(
-                            idToken, principal.getClaim().toString(), serviceEndpoints).getAccessToken();
+                    graphApiToken = client.acquireTokenForGraphApi(idToken).getAccessToken();
+                    principal.setUserGroups(client.getGroups(graphApiToken));
+
                     request.getSession().setAttribute(CURRENT_USER_PRINCIPAL, principal);
                     request.getSession().setAttribute(CURRENT_USER_PRINCIPAL_GRAPHAPI_TOKEN, graphApiToken);
                 }
 
-                final Authentication authentication = new
-                        PreAuthenticatedAuthenticationToken(
-                        principal, null,
-                        principal.getAuthoritiesByUserGroups(
-                                principal.getGroups(graphApiToken),
-                                aadAuthFilterProp.getActiveDirectoryGroups()));
+                final Authentication authentication = new PreAuthenticatedAuthenticationToken(
+                            principal, null, client.getGrantedAuthorities(graphApiToken));
+
                 authentication.setAuthenticated(true);
                 log.info("Request token verification success. {}", authentication);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
@@ -64,7 +64,8 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
 
                 if (principal == null || graphApiToken == null || graphApiToken.isEmpty()) {
                     principal = new UserPrincipal(idToken, serviceEndpoints);
-                    graphApiToken = client.acquireTokenForGraphApi(idToken).getAccessToken();
+                    graphApiToken =
+                            client.acquireTokenForGraphApi(idToken, principal.getClaim().toString()).getAccessToken();
                     principal.setUserGroups(client.getGroups(graphApiToken));
 
                     request.getSession().setAttribute(CURRENT_USER_PRINCIPAL, principal);

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilterProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilterProperties.java
@@ -38,6 +38,8 @@ public class AADAuthenticationFilterProperties {
     @NotEmpty
     private List<String> activeDirectoryGroups;
 
+    private String tenantId;
+
     private boolean allowTelemetry = true;
 
     public boolean isAllowTelemetry() {
@@ -78,5 +80,13 @@ public class AADAuthenticationFilterProperties {
 
     public void setactiveDirectoryGroups(List<String> activeDirectoryGroups) {
         this.activeDirectoryGroups = activeDirectoryGroups;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -94,7 +94,7 @@ public class AzureADGraphClient {
 
         if (valuesNode != null) {
             valuesNode.forEach(valueNode -> {
-                if(valueNode != null && valueNode.get("objectType").asText().equals("Group")) {
+                if (valueNode != null && valueNode.get("objectType").asText().equals("Group")) {
                     final String objectID = valueNode.get("objectId").asText();
                     final String displayName = valueNode.get("displayName").asText();
                     lUserGroups.add(new UserGroup(objectID, displayName));
@@ -105,7 +105,7 @@ public class AzureADGraphClient {
         return lUserGroups;
     }
 
-    public Set<GrantedAuthority> getGrantedAuthorities(String graphApiToken) throws IOException{
+    public Set<GrantedAuthority> getGrantedAuthorities(String graphApiToken) throws IOException {
         // Fetch the authority information from the protected resource using accessToken
         final List<UserGroup> groups = getGroups(graphApiToken);
 
@@ -133,7 +133,7 @@ public class AzureADGraphClient {
         try {
             service = Executors.newFixedThreadPool(1);
             final AuthenticationContext context = new AuthenticationContext(
-                    serviceEndpoints.getAadSigninUri() + tenantId + "/",true, service);
+                    serviceEndpoints.getAadSigninUri() + tenantId + "/", true, service);
             final Future<AuthenticationResult> future = context
                     .acquireToken(serviceEndpoints.getAadGraphApiUri(), assertion, credential, null);
             result = future.get();

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -5,19 +5,55 @@
  */
 package com.microsoft.azure.spring.autoconfigure.aad;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.aad.adal4j.AuthenticationContext;
+import com.microsoft.aad.adal4j.AuthenticationResult;
+import com.microsoft.aad.adal4j.ClientCredential;
+import com.microsoft.aad.adal4j.UserAssertion;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import javax.naming.ServiceUnavailableException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 public class AzureADGraphClient {
+    private static final SimpleGrantedAuthority DEFAULT_AUTHORITY = new SimpleGrantedAuthority("ROLE_USER");
+    private static final String DEFAULE_ROLE_PREFIX = "ROLE_";
 
-    public static String getUserMembershipsV1(String accessToken, String aadMembershipRestAPI) throws IOException {
-        final URL url = new URL(aadMembershipRestAPI);
+    private String clientId;
+    private String clientSecret;
+    private String tenantId;
+    private List<String> aadTargetGroups;
+    private ServiceEndpoints serviceEndpoints;
+
+    public AzureADGraphClient(AADAuthenticationFilterProperties properties,
+                              ServiceEndpointsProperties endpointsProperties) {
+        this.clientId = properties.getClientId();
+        this.clientSecret = properties.getClientSecret();
+        this.tenantId = properties.getTenantId();
+        this.aadTargetGroups = properties.getActiveDirectoryGroups();
+        this.serviceEndpoints = endpointsProperties.getServiceEndpoints(properties.getEnvironment());
+    }
+
+    private String getUserMembershipsV1(String accessToken) throws IOException {
+        final URL url = new URL(serviceEndpoints.getAadMembershipRestUri());
 
         final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         // Set the appropriate header fields in the request header.
@@ -45,5 +81,74 @@ public class AzureADGraphClient {
             }
             return stringBuffer.toString();
         }
+    }
+
+    public List<UserGroup> getGroups(String graphApiToken) throws IOException {
+        return loadUserGroups(graphApiToken);
+    }
+
+    private List<UserGroup> loadUserGroups(String graphApiToken) throws IOException {
+        final String responseInJson = getUserMembershipsV1(graphApiToken);
+        final List<UserGroup> lUserGroups = new ArrayList<>();
+        final ObjectMapper objectMapper = JacksonObjectMapperFactory.getInstance();
+        final JsonNode rootNode = objectMapper.readValue(responseInJson, JsonNode.class);
+        final JsonNode valuesNode = rootNode.get("value");
+        int i = 0;
+        while (valuesNode != null
+                && valuesNode.get(i) != null) {
+            if (valuesNode.get(i).get("objectType").asText().equals("Group")) {
+                lUserGroups.add(new UserGroup(
+                        valuesNode.get(i).get("objectId").asText(),
+                        valuesNode.get(i).get("displayName").asText()));
+            }
+            i++;
+        }
+        return lUserGroups;
+    }
+
+    public Set<GrantedAuthority> getGrantedAuthorities(String graphApiToken) throws IOException{
+        // Fetch the authority information from the protected resource using accessToken
+        final List<UserGroup> groups = getGroups(graphApiToken);
+
+        // Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
+        final Set<GrantedAuthority> mappedAuthorities = groups.stream()
+                .filter(group -> aadTargetGroups.contains(group.getDisplayName()))
+                .map(userGroup -> new SimpleGrantedAuthority(DEFAULE_ROLE_PREFIX + userGroup.getDisplayName()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (mappedAuthorities.isEmpty()) {
+            mappedAuthorities.add(DEFAULT_AUTHORITY);
+        }
+
+        return mappedAuthorities;
+    }
+
+    public AuthenticationResult acquireTokenForGraphApi(String idToken)
+            throws MalformedURLException, ServiceUnavailableException, InterruptedException, ExecutionException {
+
+        final ClientCredential credential = new ClientCredential(clientId, clientSecret);
+        final UserAssertion assertion = new UserAssertion(idToken);
+
+        AuthenticationResult result = null;
+        ExecutorService service = null;
+        try {
+            service = Executors.newFixedThreadPool(1);
+            final AuthenticationContext context = new AuthenticationContext(
+                    serviceEndpoints.getAadSigninUri() + tenantId + "/",
+                    true, service);
+            final Future<AuthenticationResult> future = context
+                    .acquireToken(serviceEndpoints.getAadGraphApiUri(), assertion, credential, null);
+            result = future.get();
+        } finally {
+            if (service != null) {
+                service.shutdown();
+            }
+        }
+
+        if (result == null) {
+            throw new ServiceUnavailableException(
+                    "unable to acquire on-behalf-of token for client " + clientId);
+        }
+        return result;
     }
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -39,7 +39,6 @@ public class AzureADGraphClient {
 
     private String clientId;
     private String clientSecret;
-    private String tenantId;
     private List<String> aadTargetGroups;
     private ServiceEndpoints serviceEndpoints;
 
@@ -47,7 +46,6 @@ public class AzureADGraphClient {
                               ServiceEndpointsProperties endpointsProperties) {
         this.clientId = properties.getClientId();
         this.clientSecret = properties.getClientSecret();
-        this.tenantId = properties.getTenantId();
         this.aadTargetGroups = properties.getActiveDirectoryGroups();
         this.serviceEndpoints = endpointsProperties.getServiceEndpoints(properties.getEnvironment());
     }
@@ -123,7 +121,7 @@ public class AzureADGraphClient {
         return mappedAuthorities;
     }
 
-    public AuthenticationResult acquireTokenForGraphApi(String idToken)
+    public AuthenticationResult acquireTokenForGraphApi(String idToken, String tenantId)
             throws MalformedURLException, ServiceUnavailableException, InterruptedException, ExecutionException {
 
         final ClientCredential credential = new ClientCredential(clientId, clientSecret);


### PR DESCRIPTION
**Updated**: Some methods are moved from  `AADAuthenticationFilter.java` to `AzureADGraphClient.java`, in order to be reused later in spring-security-5 oauth2 update.

### Starter Names
  - active directory spring boot starter