### PR TITLE
Add auto configuration for spring-data-gremlin.

### DIFF
--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -55,6 +55,7 @@
         <azure.spring.boot.version>2.0.4-SNAPSHOT</azure.spring.boot.version>
         <azure.applicationinsights.version>1.0.9</azure.applicationinsights.version>
         <spring.data.cosmosdb.version>2.0.3</spring.data.cosmosdb.version>
+        <spring.data.gremlin.version>2.0.0</spring.data.gremlin.version>
         <microsoft.client-runtime.version>1.0.0</microsoft.client-runtime.version>
     </properties>
 
@@ -107,6 +108,14 @@
                 <artifactId>spring-data-cosmosdb</artifactId>
                 <version>${spring.data.cosmosdb.version}</version>
             </dependency>
+
+            <!-- Spring Data Gremlin library -->
+            <dependency>
+                <groupId>com.microsoft.spring.data.gremlin</groupId>
+                <artifactId>spring-data-gremlin</artifactId>
+                <version>${spring.data.gremlin.version}</version>
+            </dependency>
+
             <!-- Azure related libraries-->
             <dependency>
                 <groupId>com.microsoft.azure</groupId>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -102,6 +102,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.microsoft.spring.data.gremlin</groupId>
+            <artifactId>spring-data-gremlin</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Azure libraries-->
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinAutoConfiguration.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.gremlin;
+
+import com.microsoft.azure.telemetry.TelemetryData;
+import com.microsoft.azure.telemetry.TelemetryProxy;
+import com.microsoft.spring.data.gremlin.common.GremlinFactory;
+import com.microsoft.spring.data.gremlin.conversion.MappingGremlinConverter;
+import com.microsoft.spring.data.gremlin.mapping.GremlinMappingContext;
+import com.microsoft.spring.data.gremlin.query.GremlinTemplate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.domain.EntityScanner;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.annotation.Persistent;
+import org.springframework.lang.NonNull;
+import org.springframework.util.ClassUtils;
+
+import java.util.HashMap;
+
+@Configuration
+@ConditionalOnClass({GremlinFactory.class, GremlinTemplate.class, MappingGremlinConverter.class})
+@ConditionalOnProperty(prefix = "gremlin", value = {"endpoint", "port", "username", "password"})
+@EnableConfigurationProperties(GremlinProperties.class)
+public class GremlinAutoConfiguration {
+
+    private final GremlinProperties properties;
+
+    private final TelemetryProxy telemetryProxy;
+
+    private final ApplicationContext applicationContext;
+
+    public GremlinAutoConfiguration(@NonNull GremlinProperties properties, @NonNull ApplicationContext context) {
+        this.properties = properties;
+        this.applicationContext = context;
+        this.telemetryProxy = new TelemetryProxy(properties.isTelemetryAllowed());
+    }
+
+    private void trackCustomEvent() {
+        final HashMap<String, String> customTelemetryProperties = new HashMap<>();
+        final String[] packageNames = this.getClass().getPackage().getName().split("\\.");
+
+        if (packageNames.length > 1) {
+            customTelemetryProperties.put(TelemetryData.SERVICE_NAME, packageNames[packageNames.length - 1]);
+        }
+
+        telemetryProxy.trackEvent(ClassUtils.getUserClass(this.getClass()).getSimpleName(), customTelemetryProperties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GremlinFactory gremlinFactory() {
+        this.trackCustomEvent();
+
+        final String endpoint = this.properties.getEndpoint();
+        final String port = this.properties.getPort();
+        final String username = this.properties.getUsername();
+        final String password = this.properties.getPassword();
+
+        return new GremlinFactory(endpoint, port, username, password);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GremlinTemplate gremlinTemplate(GremlinFactory factory, MappingGremlinConverter converter) {
+        return new GremlinTemplate(factory, converter);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GremlinMappingContext gremlinMappingContext() {
+        try {
+            final GremlinMappingContext context = new GremlinMappingContext();
+
+            context.setInitialEntitySet(new EntityScanner(this.applicationContext).scan(Persistent.class));
+
+            return context;
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MappingGremlinConverter mappingGremlinConverter(GremlinMappingContext context) {
+        return new MappingGremlinConverter(context);
+    }
+}
+

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinProperties.java
@@ -30,5 +30,5 @@ public class GremlinProperties {
     @NotEmpty
     private String password;
 
-    private boolean telemetryAllowed;
+    private boolean telemetryAllowed = true;
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinProperties.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.gremlin;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties("gremlin")
+public class GremlinProperties {
+
+    @NotEmpty
+    private String endpoint;
+
+    @NotEmpty
+    private String port;
+
+    @NotEmpty
+    private String username;
+
+    @NotEmpty
+    private String password;
+
+    private boolean telemetryAllowed;
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinRepositoriesAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinRepositoriesAutoConfiguration.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.gremlin;
+
+import com.microsoft.spring.data.gremlin.repository.GremlinRepository;
+import com.microsoft.spring.data.gremlin.repository.config.GremlinRepositoryConfigurationExtension;
+import com.microsoft.spring.data.gremlin.repository.support.GremlinRepositoryFactoryBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@ConditionalOnClass({GremlinRepository.class})
+@ConditionalOnMissingBean({GremlinRepositoryFactoryBean.class, GremlinRepositoryConfigurationExtension.class})
+@ConditionalOnProperty(prefix = "spring.data.gremlin.repositories", name = "enabled", havingValue = "true",
+        matchIfMissing = true)
+@Import(GremlinRepositoriesAutoConfigureRegistrar.class)
+public class GremlinRepositoriesAutoConfiguration {
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinRepositoriesAutoConfigureRegistrar.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/gremlin/GremlinRepositoriesAutoConfigureRegistrar.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.gremlin;
+
+import com.microsoft.spring.data.gremlin.repository.config.EnableGremlinRepositories;
+import com.microsoft.spring.data.gremlin.repository.config.GremlinRepositoryConfigurationExtension;
+import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+import java.lang.annotation.Annotation;
+
+public class GremlinRepositoriesAutoConfigureRegistrar extends AbstractRepositoryConfigurationSourceSupport {
+
+    @Override
+    protected Class<? extends Annotation> getAnnotation() {
+        return EnableGremlinRepositories.class;
+    }
+
+    @Override
+    protected Class<?> getConfiguration() {
+        return EnableGremlinRepositoriesConfiguration.class;
+    }
+
+    @Override
+    protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+        return new GremlinRepositoryConfigurationExtension();
+    }
+
+    @EnableGremlinRepositories
+    private static class EnableGremlinRepositoriesConfiguration {
+
+    }
+}

--- a/azure-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/azure-spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -7,6 +7,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.data.gremlin.repositories.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Spring Data Gremlin repositories.",
+      "defaultValue": true
+    },
+    {
       "name": "azure.keyvault.enabled",
       "type": "java.lang.Boolean",
       "description": "Enable Azure Key Vault.",

--- a/azure-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/azure-spring-boot/src/main/resources/META-INF/spring.factories
@@ -4,6 +4,8 @@ org.springframework.context.ApplicationContextInitializer=\
 com.microsoft.azure.spring.autoconfigure.aad.YamlFileApplicationContextInitializer
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.microsoft.azure.spring.autoconfigure.documentdb.DocumentDBAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.documentdb.DocumentDbRepositoriesAutoConfiguration,\
+com.microsoft.azure.spring.autoconfigure.gremlin.GremlinAutoConfiguration, \
+com.microsoft.azure.spring.autoconfigure.gremlin.GremlinRepositoriesAutoConfiguration, \
 com.microsoft.azure.spring.autoconfigure.mediaservices.MediaServicesAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.servicebus.ServiceBusAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.storage.StorageAutoConfiguration,\


### PR DESCRIPTION
## Summary
* create Auto config when endpoint, port, username and password.
* create Auto config when Factory, Template and Converter.

Signed-off-by: Pan Li <panli@microsoft.com>

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - spring data gremlin boot starter

## Additional Information