### PR TITLE
Update dev version to 0.2.5-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ __pycache__
 
 # gradle
 .gradle
-/build/
+azure-spring-boot-samples/**/build/
 gradle-app.setting
 !gradle-wrapper.jar
 .gradletasknamecache

--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-spring-boot-bom</artifactId>
-    <version>0.2.4-SNAPSHOT</version>
+    <version>0.2.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Azure Spring Boot BOM</name>
@@ -52,7 +52,7 @@
         <azure.keyvault.version>1.0.0</azure.keyvault.version>
         <azure.media.version>0.9.7</azure.media.version>
         <azure.servicebus.version>1.2.5</azure.servicebus.version>
-        <azure.spring.boot.version>0.2.4-SNAPSHOT</azure.spring.boot.version>
+        <azure.spring.boot.version>0.2.5-SNAPSHOT</azure.spring.boot.version>
         <spring.data.documentdb.version>0.1.4</spring.data.documentdb.version>
         <azure.applicationinsights.version>1.0.9</azure.applicationinsights.version>
         <microsoft.client-runtime.version>1.0.0</microsoft.client-runtime.version>

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-bom</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../azure-spring-boot-bom/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-samples/pom.xml
+++ b/azure-spring-boot-samples/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-spring-boot-bom</artifactId>
-                <version>0.2.4-SNAPSHOT</version>
+                <version>0.2.5-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/azure-spring-boot-starters/azure-active-directory-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-active-directory-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-documentdb-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-documentdb-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-mediaservices-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-mediaservices-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-servicebus-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-servicebus-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/azure-storage-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-storage-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot-starters/pom.xml
+++ b/azure-spring-boot-starters/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-spring-boot-parent</artifactId>
-        <version>0.2.4-SNAPSHOT</version>
+        <version>0.2.5-SNAPSHOT</version>
         <relativePath>../azure-spring-boot-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-spring-boot-build</artifactId>
-    <version>0.2.4-SNAPSHOT</version>
+    <version>0.2.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Azure Spring Boot Build</name>


### PR DESCRIPTION
## Summary
Update develop version for all spring boot modules as `0.2.4` has been released.

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - active directory spring boot starter
  - documentdb spring boot starter
  - key vault spring boot starter
  - media services spring boot starter
  - service bus spring boot starter
  - storage spring boot starter
