### PR TITLE
fixed redundant graph call

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
@@ -81,7 +81,7 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
                 }
 
                 final Authentication authentication = new PreAuthenticatedAuthenticationToken(
-                            principal, null, client.getGrantedAuthorities(graphApiToken));
+                            principal, null, client.convetGroupToGrantedAuthorities(principal.getUserGroups()));
 
                 authentication.setAuthenticated(true);
                 log.info("Request token verification success. {}", authentication);

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
@@ -81,7 +81,7 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
                 }
 
                 final Authentication authentication = new PreAuthenticatedAuthenticationToken(
-                            principal, null, client.convetGroupToGrantedAuthorities(principal.getUserGroups()));
+                            principal, null, client.convertGroupsToGrantedAuthorities(principal.getUserGroups()));
 
                 authentication.setAuthenticated(true);
                 log.info("Request token verification success. {}", authentication);

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -108,6 +108,19 @@ public class AzureADGraphClient {
         final List<UserGroup> groups = getGroups(graphApiToken);
 
         // Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
+        final Set<GrantedAuthority> mappedAuthorities = convetGroupToGrantedAuthorities(groups);
+
+        return mappedAuthorities;
+    }
+    
+    
+    /**
+     * Converts UserGroup list to Set of GrantedAutorities
+     * @param groups
+     * @return
+     */
+    public Set<GrantedAuthority> convetGroupToGrantedAuthorities(final List<UserGroup> groups) {
+        // Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
         final Set<GrantedAuthority> mappedAuthorities = groups.stream()
                 .filter(group -> aadTargetGroups.contains(group.getDisplayName()))
                 .map(userGroup -> new SimpleGrantedAuthority(DEFAULE_ROLE_PREFIX + userGroup.getDisplayName()))

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -108,24 +108,21 @@ public class AzureADGraphClient {
         final List<UserGroup> groups = getGroups(graphApiToken);
 
         // Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
-        final Set<GrantedAuthority> mappedAuthorities = convetGroupToGrantedAuthorities(groups);
-
-        return mappedAuthorities;
+        return convertGroupsToGrantedAuthorities(groups);
     }
-    
-    
+
+
     /**
      * Converts UserGroup list to Set of GrantedAutorities
      * @param groups
      * @return
      */
-    public Set<GrantedAuthority> convetGroupToGrantedAuthorities(final List<UserGroup> groups) {
+    public Set<GrantedAuthority> convertGroupsToGrantedAuthorities(final List<UserGroup> groups) {
         // Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
         final Set<GrantedAuthority> mappedAuthorities = groups.stream()
                 .filter(group -> aadTargetGroups.contains(group.getDisplayName()))
                 .map(userGroup -> new SimpleGrantedAuthority(DEFAULE_ROLE_PREFIX + userGroup.getDisplayName()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-
         if (mappedAuthorities.isEmpty()) {
             mappedAuthorities.add(DEFAULT_AUTHORITY);
         }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipal.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipal.java
@@ -96,7 +96,7 @@ public class UserPrincipal {
         this.userGroups = groups;
     }
 
-    public List<UserGroup> getUserGroups(List<UserGroup> groups) {
+    public List<UserGroup> getUserGroups() {
         return this.userGroups;
     }
 

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClientTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClientTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.aad;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.security.core.GrantedAuthority;
+
+import com.microsoft.aad.adal4j.ClientCredential;
+
+import io.jsonwebtoken.lang.Assert;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AzureADGraphClient.class)
+public class AzureADGraphClientTest {
+
+    private AzureADGraphClient adGraphClient;
+
+    @Mock
+    private ClientCredential credential;
+
+    @Mock
+    private AADAuthenticationProperties aadAuthProps;
+
+    @Mock
+    private ServiceEndpointsProperties endpointsProps;
+    
+    @Before
+    public void setup() throws Exception {
+        adGraphClient = PowerMockito.spy(new AzureADGraphClient(credential, aadAuthProps, endpointsProps));
+    }
+
+     @Test
+     public void testConvetGroupToGrantedAuthorities() {
+         
+         final UserGroup userGroup = new UserGroup("testId", "Test_Group");
+         final List<UserGroup> userGroups =  new ArrayList<>();
+         userGroups.add(userGroup);
+         final Set<GrantedAuthority> authorities = adGraphClient.convetGroupToGrantedAuthorities(userGroups);
+         Assert.notEmpty(authorities);
+     }
+}

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClientTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClientTest.java
@@ -5,10 +5,13 @@
  */
 package com.microsoft.azure.spring.autoconfigure.aad;
 
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,10 +20,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import com.microsoft.aad.adal4j.ClientCredential;
-
-import io.jsonwebtoken.lang.Assert;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AzureADGraphClient.class)
@@ -39,16 +41,20 @@ public class AzureADGraphClientTest {
     
     @Before
     public void setup() throws Exception {
+        final List<String> activeDirectoryGroups = new ArrayList<>();
+        activeDirectoryGroups.add("Test_Group");
+        when(aadAuthProps.getActiveDirectoryGroups()).thenReturn(activeDirectoryGroups);
         adGraphClient = PowerMockito.spy(new AzureADGraphClient(credential, aadAuthProps, endpointsProps));
     }
 
      @Test
      public void testConvetGroupToGrantedAuthorities() {
          
-         final UserGroup userGroup = new UserGroup("testId", "Test_Group");
+         final String groupName = "Test_Group";
+         final UserGroup userGroup = new UserGroup("testId", groupName);
          final List<UserGroup> userGroups =  new ArrayList<>();
          userGroups.add(userGroup);
-         final Set<GrantedAuthority> authorities = adGraphClient.convetGroupToGrantedAuthorities(userGroups);
-         Assert.notEmpty(authorities);
+         final Set<GrantedAuthority> authorities = adGraphClient.convertGroupsToGrantedAuthorities(userGroups);
+         Assert.assertTrue(authorities.contains(new SimpleGrantedAuthority("ROLE_" + groupName)));
      }
 }


### PR DESCRIPTION
## Summary
This AADAuthenticationFilter was making a redundant call to Graph , the data was already available in principle 

## Issue Type
- Bug fixing

## Starter Names
  - active directory spring boot starter

## Additional Information