### PR TITLE
Update maven dependency for active directory starter readme

### DIFF
--- a/azure-spring-boot-starters/azure-active-directory-spring-boot-starter/README.md
+++ b/azure-spring-boot-starters/azure-active-directory-spring-boot-starter/README.md
@@ -27,7 +27,7 @@ If you are using Maven, add the following dependency.
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-active-directory-spring-boot-starter</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
The code sample below doesn't work in version 2.0.2, as the `OAuth2UserService` isn't yet provided in this version. A bump to 2.0.4 fixes that problem.

## Issue Type
- Bug fixing

## Starter Names
  - active directory spring boot starter

## Additional Information
In the future, this section could probably extended by including the maven bom, but this is a quick fix, that keeps the documentation accurate