### PR TITLE
use Spring utils to avoid dependency missing

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationProperties.java
@@ -5,8 +5,8 @@
  */
 package com.microsoft.azure.spring.autoconfigure.aad;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.List;

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/telemetry/TelemetryProxy.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/telemetry/TelemetryProxy.java
@@ -8,7 +8,7 @@ package com.microsoft.azure.telemetry;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.spring.support.GetHashMac;
 import com.microsoft.azure.utils.PropertyLoader;
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.Iterator;


### PR DESCRIPTION
## Summary
Previously used StringUtils introduced by application insights dependency, which will be missing after the application insights artifact changes dependency.

## Issue Type
- Bug fixing

## Starter Names
  - active directory spring boot starter

## Additional Information