### PR TITLE
adding autoconfiguration for micrometer azuremonitor registry

### DIFF
--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -112,8 +112,18 @@
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-spring-boot-metrics-starter</artifactId>
+                <version>${azure.spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-spring-boot</artifactId>
                 <version>${azure.spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>applicationinsights-core</artifactId>
+                <version>2.2.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -120,11 +120,6 @@
                 <artifactId>azure-spring-boot</artifactId>
                 <version>${azure.spring.boot.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>applicationinsights-core</artifactId>
-                <version>2.2.0-SNAPSHOT</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -34,7 +34,17 @@
         <powermock.junit4.version>1.7.0</powermock.junit4.version>
         <powermock.api.mockito2.version>1.7.0</powermock.api.mockito2.version>
         <commons.logging.version>1.2</commons.logging.version>
+        <azuremonitor.micrometer.registry>1.1.0-SNAPSHOT</azuremonitor.micrometer.registry>
+        <micrometer.core>1.1.0-SNAPSHOT</micrometer.core>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>micrometer-snapshot</id>
+            <name>micrometer-snapshot</name>
+            <url>https://repo.spring.io/libs-snapshot</url>
+        </repository>
+    </repositories>
 
     <profiles>
         <profile>
@@ -87,6 +97,27 @@
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>${commons.logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-registry-azure-monitor</artifactId>
+                <version>${azuremonitor.micrometer.registry}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+                <version>2.0.3.RELEASE</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -34,8 +34,9 @@
         <powermock.junit4.version>1.7.0</powermock.junit4.version>
         <powermock.api.mockito2.version>1.7.0</powermock.api.mockito2.version>
         <commons.logging.version>1.2</commons.logging.version>
-        <azuremonitor.micrometer.registry>1.1.0-SNAPSHOT</azuremonitor.micrometer.registry>
-        <micrometer.core>1.1.0-SNAPSHOT</micrometer.core>
+        <azuremonitor.micrometer.registry.version>1.1.0-SNAPSHOT</azuremonitor.micrometer.registry.version>
+        <micrometer.core.version>1.1.0-SNAPSHOT</micrometer.core.version>
+        <spring-boot-actuator-autoconfigure.version>2.0.3.RELEASE</spring-boot-actuator-autoconfigure.version>
     </properties>
 
     <repositories>
@@ -101,17 +102,17 @@
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-azure-monitor</artifactId>
-                <version>${azuremonitor.micrometer.registry}</version>
+                <version>${azuremonitor.micrometer.registry.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-core</artifactId>
-                <version>${micrometer.core}</version>
+                <version>${micrometer.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-                <version>2.0.3.RELEASE</version>
+                <version>${spring-boot-actuator-autoconfigure.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>io.micrometer</groupId>

--- a/azure-spring-boot-starters/azure-spring-boot-metrics-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-spring-boot-metrics-starter/pom.xml
@@ -31,11 +31,6 @@
             <artifactId>micrometer-registry-azure-monitor</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator-autoconfigure</artifactId>
             <exclusions>

--- a/azure-spring-boot-starters/azure-spring-boot-metrics-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-spring-boot-metrics-starter/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-spring-boot-parent</artifactId>
+        <version>2.0.6-SNAPSHOT</version>
+        <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>azure-spring-boot-metrics-starter</artifactId>
+
+    <name>Azure Metrics Spring Boot Starter</name>
+    <description>Spring Boot Starter for Micrometer Metrics</description>
+    <url>https://github.com/Microsoft/azure-spring-boot</url>
+
+    <properties>
+        <project.rootdir>${project.basedir}/../..</project.rootdir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-azure-monitor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/azure-spring-boot-starters/pom.xml
+++ b/azure-spring-boot-starters/pom.xml
@@ -20,6 +20,7 @@
 
     <modules>
         <module>azure-spring-boot-starter</module>
+        <module>azure-spring-boot-metrics-starter</module>
         <module>azure-active-directory-spring-boot-starter</module>
         <module>azure-cosmosdb-spring-boot-starter</module>
         <module>azure-keyvault-secrets-spring-boot-starter</module>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -142,6 +142,31 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-core</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Micrometer metrics -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-azure-monitor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.1.0-SNAPSHOT</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Annotation processor -->
@@ -177,6 +202,7 @@
             <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -142,7 +142,6 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-core</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Micrometer metrics -->

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -153,7 +153,6 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfiguration.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.spring.autoconfigure.metrics;
+
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import io.micrometer.azuremonitor.AzureMonitorConfig;
+import io.micrometer.azuremonitor.AzureMonitorMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.util.StringUtils;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-Configuration for exporting metrics to Azure Application Insights.
+ *
+ * @author Dhaval Doshi
+ */
+@Configuration
+@AutoConfigureBefore({ CompositeMeterRegistryAutoConfiguration.class,
+    SimpleMetricsExportAutoConfiguration.class })
+@AutoConfigureAfter(MetricsAutoConfiguration.class)
+@ConditionalOnBean(Clock.class)
+@ConditionalOnClass(AzureMonitorMeterRegistry.class)
+@ConditionalOnProperty(prefix = "management.metrics.export.azure.azuremonitor",
+    name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(AzureMonitorProperties.class)
+public class AzureMonitorMetricsExportAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public AzureMonitorConfig azureConfig(AzureMonitorProperties properties) {
+    return new AzureMonitorPropertiesConfigAdapter(properties);
+  }
+
+  /**
+   * This bean is already available when the
+   * {@see <a href="https://github.com/Microsoft/ApplicationInsights-Java/tree/master/
+   * azure-application-insights-spring-boot-starter">Azure Application Insights starter</a>}
+   * is present.
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  public TelemetryConfiguration telemetryConfiguration(AzureMonitorConfig config) {
+    // Gets the active instance of TelemetryConfiguration either created by starter or xml
+    final TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.getActive();
+    if (StringUtils.isEmpty(telemetryConfiguration.getInstrumentationKey())) {
+      telemetryConfiguration.setInstrumentationKey(config.instrumentationKey());
+    }
+    return telemetryConfiguration;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public AzureMonitorMeterRegistry azureMeterRegistry(AzureMonitorConfig config,
+      TelemetryConfiguration configuration, Clock clock) {
+    return new AzureMonitorMeterRegistry(config, clock, configuration);
+  }
+
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(MetricsAutoConfiguration.class)
 @ConditionalOnBean(Clock.class)
 @ConditionalOnClass(AzureMonitorMeterRegistry.class)
-@ConditionalOnProperty(prefix = "management.metrics.export.azure.azuremonitor",
+@ConditionalOnProperty(prefix = "management.metrics.export.azuremonitor",
     name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(AzureMonitorProperties.class)
 public class AzureMonitorMetricsExportAutoConfiguration {

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfiguration.java
@@ -30,44 +30,44 @@ import org.springframework.context.annotation.Configuration;
  * @author Dhaval Doshi
  */
 @Configuration
-@AutoConfigureBefore({ CompositeMeterRegistryAutoConfiguration.class,
-    SimpleMetricsExportAutoConfiguration.class })
+@AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,
+        SimpleMetricsExportAutoConfiguration.class})
 @AutoConfigureAfter(MetricsAutoConfiguration.class)
 @ConditionalOnBean(Clock.class)
 @ConditionalOnClass(AzureMonitorMeterRegistry.class)
 @ConditionalOnProperty(prefix = "management.metrics.export.azuremonitor",
-    name = "enabled", havingValue = "true", matchIfMissing = true)
+        name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(AzureMonitorProperties.class)
 public class AzureMonitorMetricsExportAutoConfiguration {
 
-  @Bean
-  @ConditionalOnMissingBean
-  public AzureMonitorConfig azureConfig(AzureMonitorProperties properties) {
-    return new AzureMonitorPropertiesConfigAdapter(properties);
-  }
-
-  /**
-   * This bean is already available when the
-   * {@see <a href="https://github.com/Microsoft/ApplicationInsights-Java/tree/master/
-   * azure-application-insights-spring-boot-starter">Azure Application Insights starter</a>}
-   * is present.
-   */
-  @Bean
-  @ConditionalOnMissingBean
-  public TelemetryConfiguration telemetryConfiguration(AzureMonitorConfig config) {
-    // Gets the active instance of TelemetryConfiguration either created by starter or xml
-    final TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.getActive();
-    if (StringUtils.isEmpty(telemetryConfiguration.getInstrumentationKey())) {
-      telemetryConfiguration.setInstrumentationKey(config.instrumentationKey());
+    @Bean
+    @ConditionalOnMissingBean
+    public AzureMonitorConfig azureConfig(AzureMonitorProperties properties) {
+        return new AzureMonitorPropertiesConfigAdapter(properties);
     }
-    return telemetryConfiguration;
-  }
 
-  @Bean
-  @ConditionalOnMissingBean
-  public AzureMonitorMeterRegistry azureMeterRegistry(AzureMonitorConfig config,
-      TelemetryConfiguration configuration, Clock clock) {
-    return new AzureMonitorMeterRegistry(config, clock, configuration);
-  }
+    /**
+     * This bean is already available when the
+     * {@see <a href="https://github.com/Microsoft/ApplicationInsights-Java/tree/master/
+     * azure-application-insights-spring-boot-starter">Azure Application Insights starter</a>}
+     * is present.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public TelemetryConfiguration telemetryConfiguration(AzureMonitorConfig config) {
+        // Gets the active instance of TelemetryConfiguration either created by starter or xml
+        final TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.getActive();
+        if (StringUtils.isEmpty(telemetryConfiguration.getInstrumentationKey())) {
+            telemetryConfiguration.setInstrumentationKey(config.instrumentationKey());
+        }
+        return telemetryConfiguration;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AzureMonitorMeterRegistry azureMeterRegistry(AzureMonitorConfig config,
+                                                        TelemetryConfiguration configuration, Clock clock) {
+        return new AzureMonitorMeterRegistry(config, clock, configuration);
+    }
 
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorProperties.java
@@ -16,13 +16,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "management.metrics.export.azuremonitor")
 public class AzureMonitorProperties extends StepRegistryProperties {
-  private String instrumentationKey;
+    private String instrumentationKey;
 
-  public String getInstrumentationKey() {
-    return this.instrumentationKey;
-  }
+    public String getInstrumentationKey() {
+        return this.instrumentationKey;
+    }
 
-  public void setInstrumentationKey(String instrumentationKey) {
-    this.instrumentationKey = instrumentationKey;
-  }
+    public void setInstrumentationKey(String instrumentationKey) {
+        this.instrumentationKey = instrumentationKey;
+    }
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorProperties.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.spring.autoconfigure.metrics;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for configuring Azure Application Insights metrics export.
+ *
+ * @author Dhaval Doshi
+ */
+@ConfigurationProperties(prefix = "management.metrics.export.azuremonitor")
+public class AzureMonitorProperties extends StepRegistryProperties {
+  private String instrumentationKey;
+
+  public String getInstrumentationKey() {
+    return this.instrumentationKey;
+  }
+
+  public void setInstrumentationKey(String instrumentationKey) {
+    this.instrumentationKey = instrumentationKey;
+  }
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesConfigAdapter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesConfigAdapter.java
@@ -15,14 +15,14 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.
  * @author Dhaval Doshi
  */
 public class AzureMonitorPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<AzureMonitorProperties>
-    implements AzureMonitorConfig {
+        implements AzureMonitorConfig {
 
-  AzureMonitorPropertiesConfigAdapter(AzureMonitorProperties properties) {
-    super(properties);
-  }
+    AzureMonitorPropertiesConfigAdapter(AzureMonitorProperties properties) {
+        super(properties);
+    }
 
-  @Override
-  public String instrumentationKey() {
-    return get(AzureMonitorProperties::getInstrumentationKey, AzureMonitorConfig.super::instrumentationKey);
-  }
+    @Override
+    public String instrumentationKey() {
+        return get(AzureMonitorProperties::getInstrumentationKey, AzureMonitorConfig.super::instrumentationKey);
+    }
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesConfigAdapter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesConfigAdapter.java
@@ -17,8 +17,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.
 public class AzureMonitorPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<AzureMonitorProperties>
     implements AzureMonitorConfig {
 
-  AzureMonitorPropertiesConfigAdapter(
-      AzureMonitorProperties properties) {
+  AzureMonitorPropertiesConfigAdapter(AzureMonitorProperties properties) {
     super(properties);
   }
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesConfigAdapter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesConfigAdapter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.spring.autoconfigure.metrics;
+
+import io.micrometer.azuremonitor.AzureMonitorConfig;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryPropertiesConfigAdapter;
+
+/**
+ * Adapter to convert {@link AzureMonitorProperties} to a {@link AzureMonitorConfig}.
+ *
+ * @author Dhaval Doshi
+ */
+public class AzureMonitorPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<AzureMonitorProperties>
+    implements AzureMonitorConfig {
+
+  AzureMonitorPropertiesConfigAdapter(
+      AzureMonitorProperties properties) {
+    super(properties);
+  }
+
+  @Override
+  public String instrumentationKey() {
+    return get(AzureMonitorProperties::getInstrumentationKey, AzureMonitorConfig.super::instrumentationKey);
+  }
+}

--- a/azure-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/azure-spring-boot/src/main/resources/META-INF/spring.factories
@@ -10,4 +10,5 @@ com.microsoft.azure.spring.autoconfigure.mediaservices.MediaServicesAutoConfigur
 com.microsoft.azure.spring.autoconfigure.servicebus.ServiceBusAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.storage.StorageAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.aad.AADAuthenticationFilterAutoConfiguration,\
-com.microsoft.azure.spring.autoconfigure.aad.AADOAuth2AutoConfiguration
+com.microsoft.azure.spring.autoconfigure.aad.AADOAuth2AutoConfiguration,\
+com.microsoft.azure.spring.autoconfigure.metrics.AzureMonitorMetricsExportAutoConfiguration

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfigurationTests.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfigurationTests.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import io.micrometer.azuremonitor.AzureMonitorConfig;
+import io.micrometer.azuremonitor.AzureMonitorMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import java.util.Map;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Tests for autoconfiguration of {@link AzureMonitorMetricsExportAutoConfiguration}
+ * @author Dhaval Doshi
+ */
+public class AzureMonitorMetricsExportAutoConfigurationTests {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withConfiguration(AutoConfigurations
+          .of(AzureMonitorMetricsExportAutoConfiguration.class));
+
+  @Test
+  public void backsOffWithoutAClock() {
+    this.contextRunner.run((context) -> assertThat(context)
+        .doesNotHaveBean(AzureMonitorMeterRegistry.class));
+  }
+
+  @Test
+  @Ignore("Somewhere in the class path there is xml from where the config is picked for AI")
+  public void failsWithoutAnApiKey() {
+    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+        .run((context) -> assertThat(context).hasFailed());
+  }
+
+  @Test
+  public void autoConfiguresConfigAndMeterRegistry() {
+    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+        .withPropertyValues(
+            "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+        .run((context) -> assertThat(context)
+            .hasSingleBean(AzureMonitorMeterRegistry.class)
+            .hasSingleBean(AzureMonitorConfig.class));
+  }
+
+  @Test
+  public void autoConfigurationCanBeDisabled() {
+    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+        .withPropertyValues(
+            "management.metrics.export.azure.azuremonitor.enabled=false")
+        .run((context) -> assertThat(context)
+            .doesNotHaveBean(AzureMonitorMeterRegistry.class)
+            .doesNotHaveBean(AzureMonitorConfig.class));
+  }
+
+  @Test
+  public void allowsCustomConfigToBeUsed() {
+    this.contextRunner.withUserConfiguration(CustomConfigConfiguration.class)
+        .run((context) -> assertThat(context)
+            .hasSingleBean(AzureMonitorMeterRegistry.class)
+            .hasSingleBean(AzureMonitorConfig.class).hasBean("customConfig"));
+  }
+
+  @Test
+  public void allowsCustomRegistryToBeUsed() {
+    this.contextRunner.withUserConfiguration(CustomRegistryConfiguration.class)
+        .withPropertyValues(
+            "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+        .run((context) -> assertThat(context)
+            .hasSingleBean(AzureMonitorMeterRegistry.class)
+            .hasBean("customRegistry")
+            .hasSingleBean(AzureMonitorConfig.class));
+  }
+
+  @Test
+  public void stopsMeterRegistryWhenContextIsClosed() {
+    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+        .withPropertyValues(
+            "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+        .run((context) -> {
+          final AzureMonitorMeterRegistry registry = spyOnDisposableBean(
+              AzureMonitorMeterRegistry.class, context);
+          context.close();
+          verify(registry).stop();
+        });
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T spyOnDisposableBean(Class<T> type,
+      AssertableApplicationContext context) {
+    final String[] names = context.getBeanNamesForType(type);
+    assertThat(names).hasSize(1);
+    final String registryBeanName = names[0];
+    final Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
+        .getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
+    final Object registryAdapter = disposableBeans.get(registryBeanName);
+    final T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
+    ReflectionTestUtils.setField(registryAdapter, "bean", registry);
+    return registry;
+  }
+
+  @Configuration
+  static class BaseConfiguration {
+
+    @Bean
+    public Clock clock() {
+      return Clock.SYSTEM;
+    }
+
+  }
+
+  @Configuration
+  @Import(BaseConfiguration.class)
+  static class CustomConfigConfiguration {
+
+    @Bean
+    public AzureMonitorConfig customConfig() {
+      return new AzureMonitorConfig() {
+
+        @Override
+        public String get(String k) {
+          if ("azuremonitor.instrumentation-key".equals(k)) {
+            return "12345";
+          }
+          return null;
+        }
+
+      };
+    }
+
+  }
+
+  @Configuration
+  @Import(BaseConfiguration.class)
+  static class CustomRegistryConfiguration {
+
+    @Bean
+    public AzureMonitorMeterRegistry customRegistry(AzureMonitorConfig config,
+        Clock clock) {
+      return new AzureMonitorMeterRegistry(config, clock, null);
+    }
+
+  }
+
+}

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfigurationTests.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfigurationTests.java
@@ -5,14 +5,9 @@
  */
 package com.microsoft.azure.spring.autoconfigure.metrics;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
 import io.micrometer.azuremonitor.AzureMonitorConfig;
 import io.micrometer.azuremonitor.AzureMonitorMeterRegistry;
 import io.micrometer.core.instrument.Clock;
-import java.util.Map;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -23,136 +18,143 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 /**
  * Tests for autoconfiguration of {@link AzureMonitorMetricsExportAutoConfiguration}
+ *
  * @author Dhaval Doshi
  */
 public class AzureMonitorMetricsExportAutoConfigurationTests {
 
-  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-      .withConfiguration(AutoConfigurations
-          .of(AzureMonitorMetricsExportAutoConfiguration.class));
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations
+                    .of(AzureMonitorMetricsExportAutoConfiguration.class));
 
-  @Test
-  public void backsOffWithoutAClock() {
-    this.contextRunner.run((context) -> assertThat(context)
-        .doesNotHaveBean(AzureMonitorMeterRegistry.class));
-  }
-
-  @Test
-  @Ignore("Somewhere in the class path there is xml from where the config is picked for AI")
-  public void failsWithoutAnApiKey() {
-    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
-        .run((context) -> assertThat(context).hasFailed());
-  }
-
-  @Test
-  public void autoConfiguresConfigAndMeterRegistry() {
-    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
-        .withPropertyValues(
-            "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
-        .run((context) -> assertThat(context)
-            .hasSingleBean(AzureMonitorMeterRegistry.class)
-            .hasSingleBean(AzureMonitorConfig.class));
-  }
-
-  @Test
-  public void autoConfigurationCanBeDisabled() {
-    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
-        .withPropertyValues(
-            "management.metrics.export.azure.azuremonitor.enabled=false")
-        .run((context) -> assertThat(context)
-            .doesNotHaveBean(AzureMonitorMeterRegistry.class)
-            .doesNotHaveBean(AzureMonitorConfig.class));
-  }
-
-  @Test
-  public void allowsCustomConfigToBeUsed() {
-    this.contextRunner.withUserConfiguration(CustomConfigConfiguration.class)
-        .run((context) -> assertThat(context)
-            .hasSingleBean(AzureMonitorMeterRegistry.class)
-            .hasSingleBean(AzureMonitorConfig.class).hasBean("customConfig"));
-  }
-
-  @Test
-  public void allowsCustomRegistryToBeUsed() {
-    this.contextRunner.withUserConfiguration(CustomRegistryConfiguration.class)
-        .withPropertyValues(
-            "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
-        .run((context) -> assertThat(context)
-            .hasSingleBean(AzureMonitorMeterRegistry.class)
-            .hasBean("customRegistry")
-            .hasSingleBean(AzureMonitorConfig.class));
-  }
-
-  @Test
-  public void stopsMeterRegistryWhenContextIsClosed() {
-    this.contextRunner.withUserConfiguration(BaseConfiguration.class)
-        .withPropertyValues(
-            "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
-        .run((context) -> {
-          final AzureMonitorMeterRegistry registry = spyOnDisposableBean(
-              AzureMonitorMeterRegistry.class, context);
-          context.close();
-          verify(registry).stop();
-        });
-  }
-
-  @SuppressWarnings("unchecked")
-  private <T> T spyOnDisposableBean(Class<T> type,
-      AssertableApplicationContext context) {
-    final String[] names = context.getBeanNamesForType(type);
-    assertThat(names).hasSize(1);
-    final String registryBeanName = names[0];
-    final Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
-        .getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
-    final Object registryAdapter = disposableBeans.get(registryBeanName);
-    final T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
-    ReflectionTestUtils.setField(registryAdapter, "bean", registry);
-    return registry;
-  }
-
-  @Configuration
-  static class BaseConfiguration {
-
-    @Bean
-    public Clock clock() {
-      return Clock.SYSTEM;
+    @Test
+    public void backsOffWithoutAClock() {
+        this.contextRunner.run((context) -> assertThat(context)
+                .doesNotHaveBean(AzureMonitorMeterRegistry.class));
     }
 
-  }
+    @Test
+    @Ignore("Somewhere in the class path there is xml from where the config is picked for AI")
+    public void failsWithoutAnApiKey() {
+        this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+                .run((context) -> assertThat(context).hasFailed());
+    }
 
-  @Configuration
-  @Import(BaseConfiguration.class)
-  static class CustomConfigConfiguration {
+    @Test
+    public void autoConfiguresConfigAndMeterRegistry() {
+        this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+                .withPropertyValues(
+                        "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+                .run((context) -> assertThat(context)
+                        .hasSingleBean(AzureMonitorMeterRegistry.class)
+                        .hasSingleBean(AzureMonitorConfig.class));
+    }
 
-    @Bean
-    public AzureMonitorConfig customConfig() {
-      return new AzureMonitorConfig() {
+    @Test
+    public void autoConfigurationCanBeDisabled() {
+        this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+                .withPropertyValues(
+                        "management.metrics.export.azure.azuremonitor.enabled=false")
+                .run((context) -> assertThat(context)
+                        .doesNotHaveBean(AzureMonitorMeterRegistry.class)
+                        .doesNotHaveBean(AzureMonitorConfig.class));
+    }
 
-        @Override
-        public String get(String k) {
-          if ("azuremonitor.instrumentation-key".equals(k)) {
-            return "12345";
-          }
-          return null;
+    @Test
+    public void allowsCustomConfigToBeUsed() {
+        this.contextRunner.withUserConfiguration(CustomConfigConfiguration.class)
+                .run((context) -> assertThat(context)
+                        .hasSingleBean(AzureMonitorMeterRegistry.class)
+                        .hasSingleBean(AzureMonitorConfig.class).hasBean("customConfig"));
+    }
+
+    @Test
+    public void allowsCustomRegistryToBeUsed() {
+        this.contextRunner.withUserConfiguration(CustomRegistryConfiguration.class)
+                .withPropertyValues(
+                        "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+                .run((context) -> assertThat(context)
+                        .hasSingleBean(AzureMonitorMeterRegistry.class)
+                        .hasBean("customRegistry")
+                        .hasSingleBean(AzureMonitorConfig.class));
+    }
+
+    @Test
+    public void stopsMeterRegistryWhenContextIsClosed() {
+        this.contextRunner.withUserConfiguration(BaseConfiguration.class)
+                .withPropertyValues(
+                        "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+                .run((context) -> {
+                    final AzureMonitorMeterRegistry registry = spyOnDisposableBean(
+                            AzureMonitorMeterRegistry.class, context);
+                    context.close();
+                    verify(registry).stop();
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T spyOnDisposableBean(Class<T> type,
+                                      AssertableApplicationContext context) {
+        final String[] names = context.getBeanNamesForType(type);
+        assertThat(names).hasSize(1);
+        final String registryBeanName = names[0];
+        final Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
+                .getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
+        final Object registryAdapter = disposableBeans.get(registryBeanName);
+        final T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
+        ReflectionTestUtils.setField(registryAdapter, "bean", registry);
+        return registry;
+    }
+
+    @Configuration
+    static class BaseConfiguration {
+
+        @Bean
+        public Clock clock() {
+            return Clock.SYSTEM;
         }
 
-      };
     }
 
-  }
+    @Configuration
+    @Import(BaseConfiguration.class)
+    static class CustomConfigConfiguration {
 
-  @Configuration
-  @Import(BaseConfiguration.class)
-  static class CustomRegistryConfiguration {
+        @Bean
+        public AzureMonitorConfig customConfig() {
+            return new AzureMonitorConfig() {
 
-    @Bean
-    public AzureMonitorMeterRegistry customRegistry(AzureMonitorConfig config,
-        Clock clock) {
-      return new AzureMonitorMeterRegistry(config, clock, null);
+                @Override
+                public String get(String k) {
+                    if ("azuremonitor.instrumentation-key".equals(k)) {
+                        return "12345";
+                    }
+                    return null;
+                }
+
+            };
+        }
+
     }
 
-  }
+    @Configuration
+    @Import(BaseConfiguration.class)
+    static class CustomRegistryConfiguration {
+
+        @Bean
+        public AzureMonitorMeterRegistry customRegistry(AzureMonitorConfig config,
+                                                        Clock clock) {
+            return new AzureMonitorMeterRegistry(config, clock, null);
+        }
+
+    }
 
 }

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfigurationTests.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorMetricsExportAutoConfigurationTests.java
@@ -52,7 +52,7 @@ public class AzureMonitorMetricsExportAutoConfigurationTests {
     public void autoConfiguresConfigAndMeterRegistry() {
         this.contextRunner.withUserConfiguration(BaseConfiguration.class)
                 .withPropertyValues(
-                        "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+                        "management.metrics.export.azuremonitor.instrumentation-key=fakekey")
                 .run((context) -> assertThat(context)
                         .hasSingleBean(AzureMonitorMeterRegistry.class)
                         .hasSingleBean(AzureMonitorConfig.class));
@@ -62,7 +62,7 @@ public class AzureMonitorMetricsExportAutoConfigurationTests {
     public void autoConfigurationCanBeDisabled() {
         this.contextRunner.withUserConfiguration(BaseConfiguration.class)
                 .withPropertyValues(
-                        "management.metrics.export.azure.azuremonitor.enabled=false")
+                        "management.metrics.export.azuremonitor.enabled=false")
                 .run((context) -> assertThat(context)
                         .doesNotHaveBean(AzureMonitorMeterRegistry.class)
                         .doesNotHaveBean(AzureMonitorConfig.class));
@@ -80,7 +80,7 @@ public class AzureMonitorMetricsExportAutoConfigurationTests {
     public void allowsCustomRegistryToBeUsed() {
         this.contextRunner.withUserConfiguration(CustomRegistryConfiguration.class)
                 .withPropertyValues(
-                        "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+                        "management.metrics.export.azuremonitor.instrumentation-key=fakekey")
                 .run((context) -> assertThat(context)
                         .hasSingleBean(AzureMonitorMeterRegistry.class)
                         .hasBean("customRegistry")
@@ -91,7 +91,7 @@ public class AzureMonitorMetricsExportAutoConfigurationTests {
     public void stopsMeterRegistryWhenContextIsClosed() {
         this.contextRunner.withUserConfiguration(BaseConfiguration.class)
                 .withPropertyValues(
-                        "management.metrics.export.azure.azuremonitor.instrumentation-key=fakekey")
+                        "management.metrics.export.azuremonitor.instrumentation-key=fakekey")
                 .run((context) -> {
                     final AzureMonitorMeterRegistry registry = spyOnDisposableBean(
                             AzureMonitorMeterRegistry.class, context);

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.azuremonitor.AzureMonitorConfig;
+import io.micrometer.core.instrument.step.StepRegistryConfig;
+import org.junit.Test;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
+
+/**
+ * Tests for {@link AzureMonitorProperties}.
+ *
+ * @author Dhaval Doshi
+ */
+
+public class AzureMonitorPropertiesTest  {
+
+  private void assertStepRegistryDefaultValues(StepRegistryProperties properties,
+      StepRegistryConfig config) {
+
+    assertThat(properties.getStep()).isEqualTo(config.step());
+    assertThat(properties.isEnabled()).isEqualTo(config.enabled());
+    assertThat(properties.getConnectTimeout()).isEqualTo(config.connectTimeout());
+    assertThat(properties.getReadTimeout()).isEqualTo(config.readTimeout());
+    assertThat(properties.getNumThreads()).isEqualTo(config.numThreads());
+    assertThat(properties.getBatchSize()).isEqualTo(config.batchSize());
+  }
+
+  @Test
+  public void defaultValuesAreConsistent() {
+    final AzureMonitorProperties properties = new AzureMonitorProperties();
+    final AzureMonitorConfig config = AzureMonitorConfig.DEFAULT;
+    assertStepRegistryDefaultValues(properties, config);
+  }
+
+}

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/metrics/AzureMonitorPropertiesTest.java
@@ -5,12 +5,12 @@
  */
 package com.microsoft.azure.spring.autoconfigure.metrics;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.micrometer.azuremonitor.AzureMonitorConfig;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 import org.junit.Test;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link AzureMonitorProperties}.
@@ -18,24 +18,24 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.
  * @author Dhaval Doshi
  */
 
-public class AzureMonitorPropertiesTest  {
+public class AzureMonitorPropertiesTest {
 
-  private void assertStepRegistryDefaultValues(StepRegistryProperties properties,
-      StepRegistryConfig config) {
+    private void assertStepRegistryDefaultValues(StepRegistryProperties properties,
+                                                 StepRegistryConfig config) {
 
-    assertThat(properties.getStep()).isEqualTo(config.step());
-    assertThat(properties.isEnabled()).isEqualTo(config.enabled());
-    assertThat(properties.getConnectTimeout()).isEqualTo(config.connectTimeout());
-    assertThat(properties.getReadTimeout()).isEqualTo(config.readTimeout());
-    assertThat(properties.getNumThreads()).isEqualTo(config.numThreads());
-    assertThat(properties.getBatchSize()).isEqualTo(config.batchSize());
-  }
+        assertThat(properties.getStep()).isEqualTo(config.step());
+        assertThat(properties.isEnabled()).isEqualTo(config.enabled());
+        assertThat(properties.getConnectTimeout()).isEqualTo(config.connectTimeout());
+        assertThat(properties.getReadTimeout()).isEqualTo(config.readTimeout());
+        assertThat(properties.getNumThreads()).isEqualTo(config.numThreads());
+        assertThat(properties.getBatchSize()).isEqualTo(config.batchSize());
+    }
 
-  @Test
-  public void defaultValuesAreConsistent() {
-    final AzureMonitorProperties properties = new AzureMonitorProperties();
-    final AzureMonitorConfig config = AzureMonitorConfig.DEFAULT;
-    assertStepRegistryDefaultValues(properties, config);
-  }
+    @Test
+    public void defaultValuesAreConsistent() {
+        final AzureMonitorProperties properties = new AzureMonitorProperties();
+        final AzureMonitorConfig config = AzureMonitorConfig.DEFAULT;
+        assertStepRegistryDefaultValues(properties, config);
+    }
 
 }


### PR DESCRIPTION
## Summary
<!--Describe the change berifly-->
This PR introduces Auto Configuration for enabling Azure Monitor Meter Registry for Micrometer (https://github.com/micrometer-metrics/micrometer/pull/806)

It introduces a new starter for metrics called - azure-spring-boot-metrics-starter (which will assist in enabling auto configuration for Azure Monitor Meter Registry to collect Pre Aggregated metrics to AzureMonitor).

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature

## Starter Names
  Adds a new starter
    - azure-spring-boot-metrics-starter

## Additional Information

Currently the dependencies rely on snapshots published by Micrometer (https://repo.spring.io/libs-snapshot/io/micrometer/micrometer-registry-azure-monitor/)  as the official next release of Micrometer would be by late sept to early oct.


Few Concerns (Please do not merge PR yet):

1. I need the help from owners of the repository in proper dependency management. Seems like even after explicitly mentioning micrometer-core:1.1.0-SNAPSHOT when I run `mvn clean package install` and use the snapshots produced in test application I still get micrometer-core:1.0.5 included which doesn't work with the implementation as it has certain classes of Micrometer core API which were introduced after 1.0.5 version.
2. I  also tried explicitly excluding `micrometer-core` from any other packages which might have it as transitive dependency but still no luck.
3. I believe that the `spring-boot-dependencies` file has `micrometer-core:1.0.5` included there which always somehow takes priority even after explicitly mentioning the 1.1.0-SNAPSHOT version to be included.

@Incarnation-p-lee  and @sophiaso  could you please help me out here? 

@grlima @littleaj  just FYI please do start taking a look!