### PR TITLE
Add sqlserver always encrypted starter for SpringBoot 1.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Starter Name | Version
 [azure-documentdb-spring-boot-starter](azure-spring-boot-starters/azure-documentdb-spring-boot-starter/README.md) | [![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-documentdb-spring-boot-starter.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.microsoft.azure%22%20AND%20a%3A%22azure-documentdb-spring-boot-starter%22)
 [azure-mediaservices-spring-boot-starter](azure-spring-boot-starters/azure-mediaservices-spring-boot-starter/README.md) | [![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-mediaservices-spring-boot-starter.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.microsoft.azure%22%20AND%20a%3A%22azure-mediaservices-spring-boot-starter%22)
 [azure-servicebus-spring-boot-starter](azure-spring-boot-starters/azure-servicebus-spring-boot-starter/README.md) | [![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-servicebus-spring-boot-starter.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.microsoft.azure%22%20AND%20a%3A%22azure-servicebus-spring-boot-starter%22)
-
+[azure-sqlserver-spring-boot-starter](azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/README.md) | [![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-sqlserver-spring-boot-starter.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.microsoft.azure%22%20AND%20a%3A%22azure-sqlserver-spring-boot-starter%22)
 
 
 ### How to Build and Contribute

--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -56,6 +56,7 @@
         <spring.data.documentdb.version>0.1.4</spring.data.documentdb.version>
         <azure.applicationinsights.version>1.0.9</azure.applicationinsights.version>
         <microsoft.client-runtime.version>1.0.0</microsoft.client-runtime.version>
+        <mssql.jdbc.version>6.4.0.jre7</mssql.jdbc.version>
     </properties>
 
     <dependencyManagement>
@@ -93,6 +94,11 @@
             <dependency>
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-mediaservices-spring-boot-starter</artifactId>
+                <version>${azure.spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-sqlserver-spring-boot-starter</artifactId>
                 <version>${azure.spring.boot.version}</version>
             </dependency>
             <dependency>
@@ -147,6 +153,11 @@
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>applicationinsights-core</artifactId>
                 <version>${azure.applicationinsights.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${mssql.jdbc.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/README.md
+++ b/azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/README.md
@@ -31,7 +31,7 @@ Open `application.properties` file and add below properties with your SQL DB cre
  To enable always encryption set the following
 
 ```properties
- spring.datasource.alwaysencrypted=true
+ spring.datasource.always-encrypted=true
  spring.datasource.always-encrypted.keyvault.client-id=
  spring.datasource.always-encrypted.keyvault.client-secret=
 ```

--- a/azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/README.md
+++ b/azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/README.md
@@ -1,0 +1,46 @@
+## Azure SQL DB AlwaysEncrypted Spring Boot Starter
+
+[Azure SQL DB Always Encrypted](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-always-encrypted) feature allows to encrypt data in SQL and store master keys in Azure KeyVault
+
+## Sample Code
+Please refer to [sample project here](../../azure-spring-boot-samples/azure-sqlserver-spring-boot-sample).
+
+## Quick Start
+
+### Add the dependency
+
+`azure-sqlserver-spring-boot-starter` is published on Maven Central Repository.
+If you are using Maven, add the following dependency.  
+
+```xml
+<dependency>
+    <groupId>com.microsoft.azure</groupId>
+    <artifactId>azure-sqlserver-spring-boot-starter</artifactId>
+</dependency>
+```
+
+### Add the property settings
+
+Open `application.properties` file and add below properties with your SQL DB credentials.
+
+ ```properties
+ spring.datasource.jdbc-url=jdbc:sqlserver://<server>.database.windows.net:1433;database=<db>;Encrypt=true;TrustServerCertificate=false;HostNameInCertificate=*.database.windows.net;loginTimeout=30
+ spring.datasource.username=
+ spring.datasource.password=
+ ```
+ To enable always encryption set the following
+
+```properties
+ spring.datasource.alwaysencrypted=true
+ spring.datasource.always-encrypted.keyvault.client-id=
+ spring.datasource.always-encrypted.keyvault.client-secret=
+```
+
+
+### Allow telemetry
+Microsoft would like to collect data about how users use this Spring boot starter. Microsoft uses this information to improve our tooling experience. Participation is voluntary. If you don't want to participate, just simply disable it by setting below configuration in `application.properties`.
+```
+azure.sqlserver.allow-telemetry=false
+```
+Find more information about Azure Service Privacy Statement, please check [Microsoft Online Services Privacy Statement](https://www.microsoft.com/en-us/privacystatement/OnlineServices/Default.aspx).
+

--- a/azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-sqlserver-spring-boot-starter/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-spring-boot-parent</artifactId>
+        <version>0.2.5-SNAPSHOT</version>
+        <relativePath>../../azure-spring-boot-parent/pom.xml</relativePath>
+    </parent>
+
+
+    <artifactId>azure-sqlserver-spring-boot-starter</artifactId>
+
+    <name>Azure SQL Server Spring Boot Starter</name>
+    <description>Spring Boot Starter for Azure SQL DB service</description>
+    <url>https://github.com/Microsoft/azure-spring-boot</url>
+
+    <properties>
+        <project.rootdir>${project.basedir}/../..</project.rootdir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+         </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-keyvault</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>adal4j</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/azure-spring-boot-starters/pom.xml
+++ b/azure-spring-boot-starters/pom.xml
@@ -26,6 +26,7 @@
         <module>azure-mediaservices-spring-boot-starter</module>
         <module>azure-servicebus-spring-boot-starter</module>
         <module>azure-storage-spring-boot-starter</module>
+        <module>azure-sqlserver-spring-boot-starter</module>
     </modules>
 
 </project>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -126,6 +126,19 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Spring JDBC -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <optional>true</optional>
+        </dependency>
+        
         <!-- Annotation processor -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AEConstants.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AEConstants.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+public class AEConstants {
+    public static final String PROPERTY_AE_ENABLED = "spring.datasource.always-encrypted.enabled";
+    public static final String PROPERTY_DATASOURCE_COL_ENCRYPT =
+                       "spring.datasource.data-source-properties.ColumnEncryptionSetting";
+    public static final String PROPERTY_CONNECTION_COL_ENCRYPT = "spring.datasource.connection-properties";
+    public static final String PROPERTY_ENCRYPTION_ENABLED_VALUE = "ColumnEncryptionSetting=Enabled";
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedAutoConfiguration.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.autoconfigure.jdbc.JndiDataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.XADataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+import javax.sql.DataSource;
+
+@Configuration
+@ConditionalOnClass({DataSource.class, EmbeddedDatabaseType.class})
+@EnableConfigurationProperties({AlwaysEncryptedDataSourceProperties.class, KeyVaultProperties.class})
+@ConditionalOnProperty(name = AEConstants.PROPERTY_AE_ENABLED)
+@AutoConfigureBefore({DataSourceAutoConfiguration.class, JndiDataSourceAutoConfiguration.class,
+        XADataSourceAutoConfiguration.class})
+public class AlwaysEncryptedAutoConfiguration {
+    private static final Logger LOG = LoggerFactory.getLogger(AlwaysEncryptedAutoConfiguration.class);
+
+    /**
+     *
+     * @return post processor bean that initializes KeyVault ofr SQL Driver
+     */
+    @Bean(name = "dataSourceKeyVaultInitializer")
+    @ConditionalOnClass(com.microsoft.sqlserver.jdbc.SQLServerDriver.class)
+    public KeyVaultProviderInitializer dataSourceKeyVaultInitializer(KeyVaultProperties properties) {
+        return new KeyVaultProviderInitializer(properties);
+    }
+
+    @Configuration
+    static class AlwaysEncryptedDataSourcePropertiesConfiguration {
+
+        @Bean
+        @Primary
+        @ConditionalOnClass(com.microsoft.sqlserver.jdbc.SQLServerDriver.class)
+        public DataSourceProperties dataSourceProperties() {
+            LOG.info("Setting AlwaysEncrypted url flag");
+            // Set Property to enable Encryption
+           return new AlwaysEncryptedDataSourceProperties();
+        }
+    }
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedDataSourceProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedDataSourceProperties.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "spring.datasource")
+public class AlwaysEncryptedDataSourceProperties extends DataSourceProperties {
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+       super.afterPropertiesSet();
+       this.setUrl(determineUrl());
+    }
+
+    @Override
+    public String determineUrl() {
+        if (!StringUtils.isEmpty(this.getUrl())) {
+            return this.getUrl() + ";" + AEConstants.PROPERTY_ENCRYPTION_ENABLED_VALUE;
+        }
+        return super.determineUrl();
+    }
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedEnvironmentPostProcessor.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedEnvironmentPostProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AlwaysEncryptedEnvironmentPostProcessor implements EnvironmentPostProcessor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlwaysEncryptedEnvironmentPostProcessor.class);
+    private static final String PROPERTY_SOURCE_NAME = "aeProperties";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+
+        if (!environment.getProperty(AEConstants.PROPERTY_AE_ENABLED, Boolean.class, false)) {
+            return;
+        }
+        LOGGER.info("Setting AlwaysEncrypted properties");
+
+        final MapPropertySource target = new MapPropertySource(PROPERTY_SOURCE_NAME, getSettingsMap(environment));
+        environment.getPropertySources().addFirst(target);
+    }
+
+    public static Map<String, Object> getSettingsMap(ConfigurableEnvironment environment) {
+        final Map<String, Object> map = new HashMap<String, Object>();
+
+        // Set Property for HikariCP
+        if (!environment.containsProperty(AEConstants.PROPERTY_DATASOURCE_COL_ENCRYPT)) {
+            map.put(AEConstants.PROPERTY_DATASOURCE_COL_ENCRYPT, "Enabled");
+        }
+        // Attach property if Tomcat Pool
+        final String connectionProps = environment.getProperty(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT);
+        if (connectionProps == null) {
+            map.put(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT,
+                    AEConstants.PROPERTY_ENCRYPTION_ENABLED_VALUE);
+        } else {
+            map.put(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT, connectionProps + ", " +
+                    AEConstants.PROPERTY_ENCRYPTION_ENABLED_VALUE);
+        }
+        return map;
+    }
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/KeyVaultProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/KeyVaultProperties.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.Assert;
+
+import javax.annotation.PostConstruct;
+
+@Getter
+@Setter
+@ConfigurationProperties("spring.datasource.always-encrypted.keyvault")
+public class KeyVaultProperties {
+
+    private String clientId;
+    private String clientSecret;
+    /**
+     * Whether allow Microsoft to collect telemetry data.
+     */
+    private boolean allowTelemetry = true;
+
+    @PostConstruct
+    public void validate() {
+        Assert.hasText(clientId, "spring.datasource.always-encrypted.keyvault.client-id must be provided");
+        Assert.hasText(clientSecret, "spring.datasource.always-encrypted.keyvault.client-secret must be provided");
+    }
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/KeyVaultProviderInitializer.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/sqlserver/KeyVaultProviderInitializer.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import com.microsoft.azure.telemetry.TelemetryData;
+import com.microsoft.azure.telemetry.TelemetryProxy;
+import com.microsoft.sqlserver.jdbc.SQLServerColumnEncryptionAzureKeyVaultProvider;
+import com.microsoft.sqlserver.jdbc.SQLServerColumnEncryptionKeyStoreProvider;
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.FatalBeanException;
+import org.springframework.util.ClassUtils;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KeyVaultProviderInitializer  {
+    private static final Logger LOG = LoggerFactory.getLogger(KeyVaultProviderInitializer.class);
+
+    private KeyVaultProperties properties;
+    private final TelemetryProxy telemetryProxy;
+
+    public  KeyVaultProviderInitializer(KeyVaultProperties properties) {
+        this.properties = properties;
+        this.telemetryProxy = new TelemetryProxy(properties.isAllowTelemetry());
+        init();
+    }
+
+    public void init() {
+        LOG.info("initializing DataSource AlwaysEncryption Vault provider");
+        trackCustomEvent();
+        try {
+
+            final SQLServerColumnEncryptionAzureKeyVaultProvider akvProvider =
+                    new SQLServerColumnEncryptionAzureKeyVaultProvider(properties.getClientId(),
+                            properties.getClientSecret());
+
+            final Map<String, SQLServerColumnEncryptionKeyStoreProvider> keyStoreMap =
+                    new HashMap<String, SQLServerColumnEncryptionKeyStoreProvider>();
+            keyStoreMap.put(akvProvider.getName(), akvProvider);
+
+            SQLServerConnection.registerColumnEncryptionKeyStoreProviders(keyStoreMap);
+
+        } catch (SQLException ex) {
+            LOG.error(ex.getMessage());
+            throw new FatalBeanException(ex.getMessage());
+        }
+    }
+
+    private void trackCustomEvent() {
+        final HashMap<String, String> customTelemetryProperties = new HashMap<>();
+
+        final String[] packageNames = this.getClass().getPackage().getName().split("\\.");
+
+        if (packageNames.length > 1) {
+            customTelemetryProperties.put(TelemetryData.SERVICE_NAME, packageNames[packageNames.length - 1]);
+        }
+        telemetryProxy.trackEvent(ClassUtils.getUserClass(this.getClass()).getSimpleName(), customTelemetryProperties);
+    }
+}

--- a/azure-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/azure-spring-boot/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.boot.env.EnvironmentPostProcessor=com.microsoft.azure.spring.cloundfoundry.environment.VcapProcessor,\
-com.microsoft.azure.keyvault.spring.KeyVaultEnvironmentPostProcessor
+com.microsoft.azure.keyvault.spring.KeyVaultEnvironmentPostProcessor,\
+com.microsoft.azure.spring.autoconfigure.sqlserver.AlwaysEncryptedEnvironmentPostProcessor
 org.springframework.context.ApplicationContextInitializer=\
 com.microsoft.azure.spring.autoconfigure.aad.YamlFileApplicationContextInitializer
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.microsoft.azure.spring.autoconfigure.documentdb.DocumentDBAutoConfiguration,\
@@ -7,4 +8,5 @@ com.microsoft.azure.spring.autoconfigure.documentdb.DocumentDbRepositoriesAutoCo
 com.microsoft.azure.spring.autoconfigure.mediaservices.MediaServicesAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.servicebus.ServiceBusAutoConfiguration,\
 com.microsoft.azure.spring.autoconfigure.storage.StorageAutoConfiguration,\
-com.microsoft.azure.spring.autoconfigure.aad.AADAuthenticationFilterAutoConfiguration
+com.microsoft.azure.spring.autoconfigure.aad.AADAuthenticationFilterAutoConfiguration,\
+com.microsoft.azure.spring.autoconfigure.sqlserver.AlwaysEncryptedAutoConfiguration

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedAutoConfigurationTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedAutoConfigurationTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static junit.framework.TestCase.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+public class AlwaysEncryptedAutoConfigurationTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @Before
+    public void setUp() {
+        this.context = new AnnotationConfigApplicationContext();
+    }
+
+    @After
+    public void tearDown() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test(expected = NoSuchBeanDefinitionException.class)
+    public void setDataEncryptionDisabled() {
+        this.context.register(SQLServerDataSource.class);
+        this.context.register(AlwaysEncryptedAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(context, AEConstants.PROPERTY_AE_ENABLED + "=false");
+        this.context.refresh();
+        assertNull (context.getBean(KeyVaultProviderInitializer.class));
+    }
+
+    @Test
+    public void setDataEncryptionEnabled() {
+        EnvironmentTestUtils.addEnvironment(context, AEConstants.PROPERTY_AE_ENABLED + "=true");
+        EnvironmentTestUtils.addEnvironment(context, KeyVaultPropertiesTest.CLIENT_ID_PROPERTY + "=id");
+        EnvironmentTestUtils.addEnvironment(context, KeyVaultPropertiesTest.CLIENT_SECRET_PROPERTY + "=secret");
+        EnvironmentTestUtils.addEnvironment(context, "spring.datasource.url=jdbc:sqlserver://xxx");
+        this.context.register(SQLServerDataSource.class);
+        this.context.register(AlwaysEncryptedAutoConfiguration.class);
+        this.context.refresh();
+        // assert beans exists
+        assertNotNull(context.getBean(KeyVaultProviderInitializer.class));
+        assertNotNull(context.getBean(KeyVaultProperties.class));
+        assertNotNull(context.getBean("dataSourceProperties"));
+        // assert properties
+        final KeyVaultProperties properties = context.getBean(KeyVaultProperties.class);
+        assertThat(properties.getClientId()).isEqualTo("id");
+        assertThat(properties.getClientSecret()).isEqualTo("secret");
+        final DataSourceProperties dsproperties = context.getBean(DataSourceProperties.class);
+        assertThat(dsproperties.getUrl().contains(AEConstants.PROPERTY_ENCRYPTION_ENABLED_VALUE));
+    }
+
+    @Test(expected = NoSuchBeanDefinitionException.class)
+    public void setDataEncryptionEnabledMissingConfig() {
+        this.context.register(SQLServerDataSource.class);
+        this.context.register(AlwaysEncryptedAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(context, AEConstants.PROPERTY_AE_ENABLED + "=true");
+        EnvironmentTestUtils.addEnvironment(context, KeyVaultPropertiesTest.CLIENT_ID_PROPERTY + "=id");
+        this.context.refresh();
+        assertNotNull(context.getBean(KeyVaultProviderInitializer.class));
+    }
+}

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedPostProcessorTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/sqlserver/AlwaysEncryptedPostProcessorTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class AlwaysEncryptedPostProcessorTest {
+
+    @Mock ConfigurableEnvironment environment;
+
+    @Test
+    public void dataSourcePropertiesEncryptionEnabled() {
+        environment = mock (ConfigurableEnvironment.class);
+        when(environment.getProperty(AEConstants.PROPERTY_DATASOURCE_COL_ENCRYPT)).thenReturn(null);
+        when(environment.getProperty(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT)).thenReturn(null);
+
+        final Map<String, Object> map = AlwaysEncryptedEnvironmentPostProcessor.getSettingsMap(environment);
+        assertThat(map.entrySet().size()).isEqualTo(2);
+        assertThat((String) map.get(AEConstants.PROPERTY_DATASOURCE_COL_ENCRYPT)).contains("Enabled");
+        assertThat((String) map.get(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT))
+                .contains("ColumnEncryptionSetting=Enabled");
+    }
+
+    @Test
+    public void connectionPropertiesEncryptionEnabled() {
+        environment = mock (ConfigurableEnvironment.class);
+        when(environment.getProperty(AEConstants.PROPERTY_DATASOURCE_COL_ENCRYPT)).thenReturn(null);
+        when(environment.getProperty(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT)).thenReturn("idleTime=10");
+
+        final Map<String, Object> map = AlwaysEncryptedEnvironmentPostProcessor.getSettingsMap(environment);
+        assertThat(map.entrySet().size()).isEqualTo(2);
+        assertThat((String) map.get(AEConstants.PROPERTY_DATASOURCE_COL_ENCRYPT)).contains("Enabled");
+        assertThat((String) map.get(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT))
+                .contains(AEConstants.PROPERTY_ENCRYPTION_ENABLED_VALUE);
+        assertThat((String) map.get(AEConstants.PROPERTY_CONNECTION_COL_ENCRYPT)).contains("idleTime=10");
+    }
+}

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/sqlserver/KeyVaultPropertiesTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/sqlserver/KeyVaultPropertiesTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.spring.autoconfigure.sqlserver;
+
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class KeyVaultPropertiesTest {
+    public static final String CLIENT_SECRET_PROPERTY = "spring.datasource.always-encrypted.keyvault.client-secret";
+    public static final String CLIENT_ID_PROPERTY = "spring.datasource.always-encrypted.keyvault.client-id";
+
+    private  AnnotationConfigApplicationContext context;
+
+    @Before
+    public void setUp() {
+        this.context = new AnnotationConfigApplicationContext();
+    }
+
+    @After
+    public void tearDown() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void canSetAllProperties() {
+        EnvironmentTestUtils.addEnvironment(context, KeyVaultPropertiesTest.CLIENT_ID_PROPERTY + "=id");
+        EnvironmentTestUtils.addEnvironment(context, KeyVaultPropertiesTest.CLIENT_SECRET_PROPERTY + "=secret");
+        this.context.register(SQLServerDataSource.class);
+        this.context.register(AlwaysEncryptedAutoConfiguration.class);
+        this.context.register(KeyVaultPropertiesTest.Config.class);
+        this.context.refresh();
+        // assert beans exists
+        assertNotNull(context.getBean(KeyVaultProperties.class));
+        // asset properties
+        final KeyVaultProperties properties = context.getBean(KeyVaultProperties.class);
+        assertEquals(properties.getClientId(), "id");
+        assertEquals(properties.getClientSecret(), "secret");
+    }
+
+    @Test(expected = BeanCreationException.class)
+    public void emptySettingNotAllowed() {
+        this.context.register(SQLServerDataSource.class);
+        this.context.register(AlwaysEncryptedAutoConfiguration.class);
+        this.context.register(KeyVaultPropertiesTest.Config.class);
+        this.context.refresh();
+        // assert beans exists
+        assertNotNull(context.getBean(KeyVaultProperties.class));
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(KeyVaultProperties.class)
+    static class Config {
+    }
+}


### PR DESCRIPTION
## Summary
Add Always Encrypted sql server enabler for Spring Boot 1.5.x apps

## Issue Type
- New Feature

## Starter Names
  - sqlserver spring boot starter

## Additional Information