### PR TITLE
Refactor aad to support serializable UserPrincipal

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserGroup.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserGroup.java
@@ -5,9 +5,12 @@
  */
 package com.microsoft.azure.spring.autoconfigure.aad;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class UserGroup {
+public class UserGroup implements Serializable {
+    private static final long serialVersionUID = 9064197572478554735L;
+
     private String objectID;
     private String displayName;
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalManager.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalManager.java
@@ -27,9 +27,9 @@ import java.text.ParseException;
 public class UserPrincipalManager {
     private static final Logger LOG = LoggerFactory.getLogger(UserPrincipalManager.class);
 
-    private ServiceEndpoints serviceEndpoints;
-    private ConfigurableJWTProcessor<SecurityContext> validator;
-    private ResourceRetriever resourceRetriever;
+    private final ServiceEndpoints serviceEndpoints;
+    private final ConfigurableJWTProcessor<SecurityContext> validator;
+    private final ResourceRetriever resourceRetriever;
 
     public UserPrincipalManager(ServiceEndpoints serviceEndpoints, ResourceRetriever resourceRetriever) {
         this.serviceEndpoints = serviceEndpoints;

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalManager.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalManager.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.autoconfigure.aad;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.ResourceRetriever;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+
+public class UserPrincipalManager {
+    private static final Logger LOG = LoggerFactory.getLogger(UserPrincipalManager.class);
+
+    private ServiceEndpoints serviceEndpoints;
+    private ConfigurableJWTProcessor<SecurityContext> validator;
+    private ResourceRetriever resourceRetriever;
+
+    public UserPrincipalManager(ServiceEndpoints serviceEndpoints, ResourceRetriever resourceRetriever) {
+        this.serviceEndpoints = serviceEndpoints;
+        this.validator = getAadJwtTokenValidator();
+        this.resourceRetriever = resourceRetriever;
+    }
+
+    public UserPrincipal buildUserPrincipal(String idToken) throws ParseException, JOSEException, BadJOSEException {
+        final JWTClaimsSet jwtClaimsSet = validator.process(idToken, null);
+        final JWTClaimsSetVerifier<SecurityContext> verifier = validator.getJWTClaimsSetVerifier();
+        verifier.verify(jwtClaimsSet, null);
+        final JWSObject jwsObject = JWSObject.parse(idToken);
+
+        return new UserPrincipal(jwsObject, jwtClaimsSet);
+    }
+
+    private ConfigurableJWTProcessor<SecurityContext> getAadJwtTokenValidator() {
+        final ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+        final JWKSource<SecurityContext> keySource;
+
+        try {
+            keySource = new RemoteJWKSet<>(new URL(serviceEndpoints.getAadKeyDiscoveryUri()), resourceRetriever);
+        } catch (MalformedURLException e) {
+            LOG.error("Failed to parse active directory key discovery uri.", e);
+            throw new IllegalStateException("Failed to parse active directory key discovery uri.", e);
+        }
+
+        final JWSAlgorithm expectedJWSAlg = JWSAlgorithm.RS256;
+        final JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
+        jwtProcessor.setJWSKeySelector(keySelector);
+
+        jwtProcessor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<SecurityContext>() {
+            @Override
+            public void verify(JWTClaimsSet claimsSet, SecurityContext ctx) throws BadJWTException {
+                super.verify(claimsSet, ctx);
+                final String issuer = claimsSet.getIssuer();
+                if (issuer == null || !issuer.contains("https://sts.windows.net/")
+                        && !issuer.contains("https://sts.chinacloudapi.cn/")) {
+                    throw new BadJWTException("Invalid token issuer");
+                }
+            }
+        });
+        return jwtProcessor;
+    }
+}

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationAutoConfigurationTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationAutoConfigurationTest.java
@@ -6,29 +6,24 @@
 package com.microsoft.azure.spring.autoconfigure.aad;
 
 import org.junit.Test;
-import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
-
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AADAuthenticationAutoConfigurationTest {
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AADAuthenticationFilterAutoConfiguration.class))
+            .withPropertyValues("azure.activedirectory.client-id=fake-client-id",
+                    "azure.activedirectory.client-secret=fake-client-secret",
+                    "azure.activedirectory.active-directory-groups=fake-group",
+                    "azure.service.endpoints.global.aadKeyDiscoveryUri=http://fake.aad.discovery.uri");
+
     @Test
-    public void createAADAuthenticationFilter() throws Exception {
-        System.setProperty(Constants.CLIENT_ID_PROPERTY, Constants.CLIENT_ID);
-        System.setProperty(Constants.CLIENT_SECRET_PROPERTY, Constants.CLIENT_SECRET);
-        System.setProperty(Constants.TARGETED_GROUPS_PROPERTY,
-                Constants.TARGETED_GROUPS.toString().replace("[", "").replace("]", ""));
-
-        try (AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext()) {
-            context.register(AADAuthenticationFilterAutoConfiguration.class);
-            context.refresh();
-
+    public void createAADAuthenticationFilter() {
+        this.contextRunner.run(context -> {
             final AADAuthenticationFilter azureADJwtTokenFilter = context.getBean(AADAuthenticationFilter.class);
             assertThat(azureADJwtTokenFilter).isNotNull();
             assertThat(azureADJwtTokenFilter).isExactlyInstanceOf(AADAuthenticationFilter.class);
-        }
-
-        System.clearProperty(Constants.CLIENT_ID_PROPERTY);
-        System.clearProperty(Constants.CLIENT_SECRET_PROPERTY);
-        System.clearProperty(Constants.TARGETED_GROUPS_PROPERTY);
+        });
     }
 }

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/Constants.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/Constants.java
@@ -16,6 +16,8 @@ public class Constants {
     public static final String TENANT_ID_PROPERTY = "azure.activedirectory.tenant-id";
 
     public static final String DEFAULT_ENVIRONMENT = "global";
+    public static final String AAD_KEYDISCOVERY_URI_PROPERTY = "azure.service.endpoints.global.aadKeyDiscoveryUri";
+    public static final String AAD_KEYDISCOVERY_URI = "http://fake.aad.discovery.uri";
     public static final String CLIENT_ID = "real_client_id";
     public static final String CLIENT_SECRET = "real_client_secret";
     public static final List<String> TARGETED_GROUPS = Arrays.asList("group1", "group2", "group3");
@@ -92,4 +94,17 @@ public class Constants {
             "00000000100000009D29CBA7B45D854A84FF7F9B636BD9DC000000000000000000000017312E322E3" +
             "834302E3131333535362E312E342E3233333100000000'\"\n" +
             "}";
+
+    /** Token from https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-id-and-access-tokens */
+    public static final String JWT_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1" +
+            "iYTlnb0VLWSJ9.eyJhdWQiOiI2NzMxZGU3Ni0xNGE2LTQ5YWUtOTdiYy02ZWJhNjkxNDM5MWUiLCJpc3MiOiJodHRwczovL2xvZ2lu" +
+            "Lm1pY3Jvc29mdG9ubGluZS5jb20vYjk0MTk4MTgtMDlhZi00OWMyLWIwYzMtNjUzYWRjMWYzNzZlL3YyLjAiLCJpYXQiOjE0NTIyOD" +
+            "UzMzEsIm5iZiI6MTQ1MjI4NTMzMSwiZXhwIjoxNDUyMjg5MjMxLCJuYW1lIjoiQmFiZSBSdXRoIiwibm9uY2UiOiIxMjM0NSIsIm9p" +
+            "ZCI6ImExZGJkZGU4LWU0ZjktNDU3MS1hZDkzLTMwNTllMzc1MGQyMyIsInByZWZlcnJlZF91c2VybmFtZSI6InRoZWdyZWF0YmFtYm" +
+            "lub0BueXkub25taWNyb3NvZnQuY29tIiwic3ViIjoiTUY0Zi1nZ1dNRWppMTJLeW5KVU5RWnBoYVVUdkxjUXVnNWpkRjJubDAxUSIs" +
+            "InRpZCI6ImI5NDE5ODE4LTA5YWYtNDljMi1iMGMzLTY1M2FkYzFmMzc2ZSIsInZlciI6IjIuMCJ9.p_rYdrtJ1oCmgDBggNHB9O38K" +
+            "TnLCMGbMDODdirdmZbmJcTHiZDdtTc-hguu3krhbtOsoYM2HJeZM3Wsbp_YcfSKDY--X_NobMNsxbT7bqZHxDnA2jTMyrmt5v2EKUn" +
+            "EeVtSiJXyO3JWUq9R0dO-m4o9_8jGP6zHtR62zLaotTBYHmgeKpZgTFB9WtUq8DVdyMn_HSvQEfz-LWqckbcTwM_9RNKoGRVk38KCh" +
+            "VJo4z5LkksYRarDo8QgQ7xEKmYmPvRr_I7gvM2bmlZQds2OeqWLB1NSNbFZqyFOCgYn3bAQ-nEQSKwBaA36jYGPOVG2r2Qv1uKcpSO" +
+            "xzxaQybzYpQ";
 }

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/Constants.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/Constants.java
@@ -16,8 +16,6 @@ public class Constants {
     public static final String TENANT_ID_PROPERTY = "azure.activedirectory.tenant-id";
 
     public static final String DEFAULT_ENVIRONMENT = "global";
-    public static final String AAD_KEYDISCOVERY_URI_PROPERTY = "azure.service.endpoints.global.aadKeyDiscoveryUri";
-    public static final String AAD_KEYDISCOVERY_URI = "http://fake.aad.discovery.uri";
     public static final String CLIENT_ID = "real_client_id";
     public static final String CLIENT_SECRET = "real_client_secret";
     public static final List<String> TARGETED_GROUPS = Arrays.asList("group1", "group2", "group3");

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/ResourceRetrieverTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/ResourceRetrieverTest.java
@@ -19,7 +19,8 @@ public class ResourceRetrieverTest {
             .withConfiguration(AutoConfigurations.of(AADAuthenticationFilterAutoConfiguration.class))
             .withPropertyValues("azure.activedirectory.client-id=fake-client-id",
                     "azure.activedirectory.client-secret=fake-client-secret",
-                    "azure.activedirectory.active-directory-groups=fake-group");
+                    "azure.activedirectory.active-directory-groups=fake-group",
+                    "azure.service.endpoints.global.aadKeyDiscoveryUri=http://fake.aad.discovery.uri");
 
     @Test
     public void resourceRetrieverDefaultConfig() {
@@ -39,7 +40,8 @@ public class ResourceRetrieverTest {
     public void resourceRetriverIsConfigurable() {
         this.contextRunner.withPropertyValues("azure.activedirectory.jwt-connect-timeout=1234",
                 "azure.activedirectory.jwt-read-timeout=1234",
-                "azure.activedirectory.jwt-size-limit=123400")
+                "azure.activedirectory.jwt-size-limit=123400",
+                "azure.service.endpoints.global.aadKeyDiscoveryUri=http://fake.aad.discovery.uri")
                 .run(context -> {
                     assertThat(context).hasSingleBean(ResourceRetriever.class);
                     final ResourceRetriever retriever = context.getBean(ResourceRetriever.class);

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalTest.java
@@ -6,6 +6,9 @@
 package com.microsoft.azure.spring.autoconfigure.aad;
 
 import com.microsoft.aad.adal4j.ClientCredential;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.junit.Assert;
 import org.junit.Before;
@@ -18,7 +21,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.StringUtils;
 
+import java.io.*;
+import java.nio.file.Files;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -74,5 +81,35 @@ public class UserPrincipalTest {
         targetedGroups.add(new UserGroup("12345678-86a4-4237-aeb0-60bad29c1de0", "group3"));
 
         Assert.assertThat(groups, IsIterableContainingInAnyOrder.containsInAnyOrder(groups.toArray()));
+    }
+
+    @Test
+    public void userPrinciplaIsSerializable() throws ParseException, IOException, ClassNotFoundException {
+        final File tmpOutputFile = File.createTempFile("test-user-principal", "txt");
+
+        try (final FileOutputStream fileOutputStream = new FileOutputStream(tmpOutputFile);
+             final ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream);
+             final FileInputStream fileInputStream = new FileInputStream(tmpOutputFile);
+             final ObjectInputStream objectInputStream = new ObjectInputStream(fileInputStream);){
+
+            final JWSObject jwsObject = JWSObject.parse(Constants.JWT_TOKEN);
+            final JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().subject("fake-subject").build();
+            final UserPrincipal principal = new UserPrincipal(jwsObject, jwtClaimsSet);
+
+            objectOutputStream.writeObject(principal);
+
+            final UserPrincipal serializedPrincipal = (UserPrincipal) objectInputStream.readObject();
+
+            Assert.assertNotNull("Serialized UserPrincipal not null", serializedPrincipal);
+            Assert.assertTrue("Serialized UserPrincipal kid not empty",
+                    !StringUtils.isEmpty(serializedPrincipal.getKid()));
+            Assert.assertNotNull("Serialized UserPrincipal claims not null.", serializedPrincipal.getClaims());
+            Assert.assertTrue("Serialized UserPrincipal claims not empty.",
+                    serializedPrincipal.getClaims().size() > 0);
+        } finally {
+            if (tmpOutputFile != null) {
+                Files.deleteIfExists(tmpOutputFile.toPath());
+            }
+        }
     }
 }


### PR DESCRIPTION
UserPrincipal was not serializable caused by 1) not implementing serializable 2) includes non-serializable variable JWKSet, as the JWKSet value can be loaded by user from public endpoint, it's removed from the UserPrincipal.

refs #321 
