### PR TITLE
initialize validator with configured ResourceRetriever

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalManager.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/UserPrincipalManager.java
@@ -33,8 +33,8 @@ public class UserPrincipalManager {
 
     public UserPrincipalManager(ServiceEndpoints serviceEndpoints, ResourceRetriever resourceRetriever) {
         this.serviceEndpoints = serviceEndpoints;
-        this.validator = getAadJwtTokenValidator();
         this.resourceRetriever = resourceRetriever;
+        this.validator = getAadJwtTokenValidator();
     }
 
     public UserPrincipal buildUserPrincipal(String idToken) throws ParseException, JOSEException, BadJOSEException {

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/ResourceRetrieverTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/ResourceRetrieverTest.java
@@ -75,11 +75,12 @@ public class ResourceRetrieverTest {
             final ResourceRetriever retriever = context.getBean(ResourceRetriever.class);
 
             final UserPrincipalManager manager = new UserPrincipalManager(endpoints, retriever);
-            final ConfigurableJWTProcessor processor = Whitebox.getInternalState(manager, ConfigurableJWTProcessor.class);
+            final ConfigurableJWTProcessor processor = Whitebox.getInternalState(manager,
+                    ConfigurableJWTProcessor.class);
             final JWSKeySelector selector = processor.getJWSKeySelector();
             final JWKSource jwkSource = Whitebox.getInternalState(selector, JWKSource.class);
             assertThat(jwkSource).isInstanceOf(RemoteJWKSet.class);
-            final ResourceRetriever validatorRetriever = ((RemoteJWKSet)jwkSource).getResourceRetriever();
+            final ResourceRetriever validatorRetriever = ((RemoteJWKSet) jwkSource).getResourceRetriever();
 
             assertThat(validatorRetriever).isInstanceOf(DefaultResourceRetriever.class);
             final DefaultResourceRetriever defaultRetriever = (DefaultResourceRetriever) retriever;


### PR DESCRIPTION
## Summary
Token validator is created before ResourceRetriever initialized, which does not take the changed timeout configuration into validator.