### PR TITLE
Enable HTTP/S toggling

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
@@ -55,15 +55,18 @@ public class StorageAutoConfiguration {
         final SharedKeyCredentials credentials = new SharedKeyCredentials(properties.getAccountName(),
                 properties.getAccountKey());
         
-        
-        final URL blobUrl = properties.isEnableHttps() ? 
-        new URL(String.format(BLOB_HTTPS_URL, properties.getAccountName())) : 
-        new URL(String.format(BLOB_URL, properties.getAccountName()));
-        
+        final URL blobUrl = getURL();
         final PipelineOptions pipelineOptions = buildOptions(options);
         final ServiceURL serviceURL = new ServiceURL(blobUrl, StorageURL.createPipeline(credentials, pipelineOptions));
 
         return serviceURL;
+    }
+    
+    private URL getURL() throws MalformedURLException{
+        if (properties.isEnableHttps()){
+            return new URL(String.format(BLOB_HTTPS_URL, properties.getAccountName()));
+        }
+        return new URL(String.format(BLOB_URL, properties.getAccountName())); 
     }
 
     private PipelineOptions buildOptions(PipelineOptions fromOptions) {

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
@@ -51,10 +51,8 @@ public class StorageAutoConfiguration {
             MalformedURLException {
         LOG.debug("Creating ServiceURL bean...");
         trackCustomEvent();
-
         final SharedKeyCredentials credentials = new SharedKeyCredentials(properties.getAccountName(),
                 properties.getAccountKey());
-        
         final URL blobUrl = getURL();
         final PipelineOptions pipelineOptions = buildOptions(options);
         final ServiceURL serviceURL = new ServiceURL(blobUrl, StorageURL.createPipeline(credentials, pipelineOptions));

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 public class StorageAutoConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(StorageAutoConfiguration.class);
     private static final String BLOB_URL = "http://%s.blob.core.windows.net";
+    private static final String BLOB_Https_URL = "https://%s.blob.core.windows.net";
     private static final String USER_AGENT_PREFIX = "spring-storage/";
 
     private final StorageProperties properties;
@@ -53,7 +54,7 @@ public class StorageAutoConfiguration {
 
         final SharedKeyCredentials credentials = new SharedKeyCredentials(properties.getAccountName(),
                 properties.getAccountKey());
-        final URL blobUrl = new URL(String.format(BLOB_URL, properties.getAccountName()));
+        final URL blobUrl = properties.isEnableHttps() ? new URL(String.format(BLOB_Https_URL, properties.getAccountName())) : new URL(String.format(BLOB_URL, properties.getAccountName()));
         final PipelineOptions pipelineOptions = buildOptions(options);
         final ServiceURL serviceURL = new ServiceURL(blobUrl, StorageURL.createPipeline(credentials, pipelineOptions));
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
@@ -60,8 +60,8 @@ public class StorageAutoConfiguration {
         return serviceURL;
     }
     
-    private URL getURL() throws MalformedURLException{
-        if (properties.isEnableHttps()){
+    private URL getURL() throws MalformedURLException {
+        if (properties.isEnableHttps()) {
             return new URL(String.format(BLOB_HTTPS_URL, properties.getAccountName()));
         }
         return new URL(String.format(BLOB_URL, properties.getAccountName())); 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfiguration.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 public class StorageAutoConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(StorageAutoConfiguration.class);
     private static final String BLOB_URL = "http://%s.blob.core.windows.net";
-    private static final String BLOB_Https_URL = "https://%s.blob.core.windows.net";
+    private static final String BLOB_HTTPS_URL = "https://%s.blob.core.windows.net";
     private static final String USER_AGENT_PREFIX = "spring-storage/";
 
     private final StorageProperties properties;
@@ -54,7 +54,12 @@ public class StorageAutoConfiguration {
 
         final SharedKeyCredentials credentials = new SharedKeyCredentials(properties.getAccountName(),
                 properties.getAccountKey());
-        final URL blobUrl = properties.isEnableHttps() ? new URL(String.format(BLOB_Https_URL, properties.getAccountName())) : new URL(String.format(BLOB_URL, properties.getAccountName()));
+        
+        
+        final URL blobUrl = properties.isEnableHttps() ? 
+        new URL(String.format(BLOB_HTTPS_URL, properties.getAccountName())) : 
+        new URL(String.format(BLOB_URL, properties.getAccountName()));
+        
         final PipelineOptions pipelineOptions = buildOptions(options);
         final ServiceURL serviceURL = new ServiceURL(blobUrl, StorageURL.createPipeline(credentials, pipelineOptions));
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageProperties.java
@@ -32,4 +32,8 @@ public class StorageProperties {
     @Getter
     @Setter
     private boolean allowTelemetry = true;
+    
+    @Getter
+    @Setter
+    private boolean enableHttps = true;
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/storage/StorageProperties.java
@@ -35,5 +35,5 @@ public class StorageProperties {
     
     @Getter
     @Setter
-    private boolean enableHttps = true;
+    private boolean enableHttps = false;
 }

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfigurationTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/storage/StorageAutoConfigurationTest.java
@@ -15,7 +15,8 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StorageAutoConfigurationTest {
-    private static final String BLOB_URL = "http://%s.blob.core.windows.net";
+    private static final String BLOB_HTTP_URL = "http://%s.blob.core.windows.net";
+    private static final String BLOB_HTTPS_URL = "https://%s.blob.core.windows.net";
     private static final String ACCOUNT_KEY = "ZmFrZUFjY291bnRLZXk="; /* Base64 encoded for string fakeAccountKey */
     private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(StorageAutoConfiguration.class));
@@ -31,7 +32,16 @@ public class StorageAutoConfigurationTest {
                 "azure.storage.account-key=" + ACCOUNT_KEY)
                 .run(context -> {
                     final ServiceURL serviceURL = context.getBean(ServiceURL.class);
-                    final String blobUrl = String.format(BLOB_URL, "fakeStorageAccountName");
+                    final String blobUrl = String.format(BLOB_HTTP_URL, "fakeStorageAccountName");
+                    assertThat(serviceURL).isNotNull();
+                    assertThat(serviceURL.toURL().toString()).isEqualTo(blobUrl);
+                });
+        
+        contextRunner.withPropertyValues("azure.storage.account-name=fakeStorageAccountName",
+                "azure.storage.account-key=" + ACCOUNT_KEY, "azure.storage.enable-https=true")
+                .run(context -> {
+                    final ServiceURL serviceURL = context.getBean(ServiceURL.class);
+                    final String blobUrl = String.format(BLOB_HTTPS_URL, "fakeStorageAccountName");
                     assertThat(serviceURL).isNotNull();
                     assertThat(serviceURL.toURL().toString()).isEqualTo(blobUrl);
                 });


### PR DESCRIPTION
## Summary
Enable HTTP/S toggle via application.properties

## Issue Type
- New Feature

## Starter Names
  - storage spring boot starter

## Additional Information
Small change, storage on azure is default to https