### PR TITLE
Add VcapProcessor referenced dependency as required, fix #534.

### DIFF
--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -24,6 +24,16 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
 
+        <!-- Ensure these following 2 dependencies exist in users bom, as the VcapProcessor bean is unconditional. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>


### PR DESCRIPTION
* As VcapProcessor bean is unconditional.

Signed-off-by: Pan Li <panli@microsoft.com>
