### PR TITLE
Use post for oauth2 client authentication method, #559.

### DIFF
--- a/azure-spring-boot/src/main/resources/aad-oauth2-common.properties
+++ b/azure-spring-boot/src/main/resources/aad-oauth2-common.properties
@@ -4,7 +4,7 @@ spring.security.oauth2.client.provider.azure.user-info-uri=https://login.microso
 spring.security.oauth2.client.provider.azure.jwk-set-uri=https://login.microsoftonline.com/common/discovery/keys
 spring.security.oauth2.client.provider.azure.user-name-attribute=name
 
-spring.security.oauth2.client.registration.azure.client-authentication-method=basic
+spring.security.oauth2.client.registration.azure.client-authentication-method=post
 spring.security.oauth2.client.registration.azure.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.azure.redirect-uri-template={baseUrl}/login/oauth2/code/{registrationId}
 spring.security.oauth2.client.registration.azure.scope=openid, https://graph.microsoft.com/user.read


### PR DESCRIPTION
* No need for encoding secret.
* No limitation for URL length and header buffer
* May little secure than basic

Signed-off-by: Pan Li <panli@microsoft.com>

