### PR TITLE
Support get token for Key Vault with MSI

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/AzureKeyVaultMSICredential.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/AzureKeyVaultMSICredential.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.keyvault.spring;
+
+import com.microsoft.azure.AzureEnvironment;
+import com.microsoft.azure.credentials.AzureTokenCredentials;
+import com.microsoft.azure.credentials.MSICredentials;
+import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
+
+import java.io.IOException;
+
+public class AzureKeyVaultMSICredential extends KeyVaultCredentials {
+    private final AzureTokenCredentials tokenCredentials;
+
+    public AzureKeyVaultMSICredential(AzureTokenCredentials tokenCredentials) {
+        this.tokenCredentials = tokenCredentials;
+    }
+
+    public AzureKeyVaultMSICredential(AzureEnvironment environment) {
+        this.tokenCredentials = new MSICredentials(environment);
+    }
+
+    public AzureKeyVaultMSICredential(AzureEnvironment environment, String clientId) {
+        this.tokenCredentials = new MSICredentials(environment).withClientId(clientId);
+    }
+
+    @Override
+    public String doAuthenticate(String authorization, String resource, String scope) {
+        try {
+            return tokenCredentials.getToken(resource);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to do authentication.", e);
+        }
+    }
+}

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorHelper.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorHelper.java
@@ -111,11 +111,11 @@ class KeyVaultEnvironmentPostProcessorHelper {
         if (this.environment.containsProperty(Constants.AZURE_KEYVAULT_CLIENT_ID)) {
             LOG.debug("Will use MSI credentials for VMs with specified clientId");
             final String clientId = getProperty(this.environment, Constants.AZURE_KEYVAULT_CLIENT_ID);
-            return new MSICredentials(AzureEnvironment.AZURE).withClientId(clientId);
+            return new AzureKeyVaultMSICredential(AzureEnvironment.AZURE, clientId);
         }
 
         LOG.debug("Will use MSI credentials for VM");
-        return new MSICredentials(AzureEnvironment.AZURE);
+        return new AzureKeyVaultMSICredential(AzureEnvironment.AZURE);
     }
 
     private String getProperty(final ConfigurableEnvironment env, final String propertyName) {

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorTest.java
@@ -78,7 +78,7 @@ public class KeyVaultEnvironmentPostProcessorTest {
 
         final ServiceClientCredentials credentials = keyVaultEnvironmentPostProcessorHelper.getCredentials();
 
-        assertThat(credentials, IsInstanceOf.instanceOf(MSICredentials.class));
+        assertThat(credentials, IsInstanceOf.instanceOf(AzureKeyVaultMSICredential.class));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class KeyVaultEnvironmentPostProcessorTest {
 
         final ServiceClientCredentials credentials = keyVaultEnvironmentPostProcessorHelper.getCredentials();
 
-        assertThat(credentials, IsInstanceOf.instanceOf(MSICredentials.class));
+        assertThat(credentials, IsInstanceOf.instanceOf(AzureKeyVaultMSICredential.class));
     }
 
     @Test


### PR DESCRIPTION
Key Vault managed identity requires getting token for resource https://vault.azure.net/,
with MSICredentials alone will use incorrect resource id https://{keyvault-name}.vault.azure.net.

refs #556 
