### PR TITLE
Add '.' separated properties to keyvault source, #641.

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultOperation.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultOperation.java
@@ -114,6 +114,7 @@ public class KeyVaultOperation {
             secrets.forEach(s -> {
                 final String secretName = s.id().replace(vaultUri + "/secrets/", "").toLowerCase(Locale.US);
                 propertyNamesHashMap.putIfAbsent(secretName, s.id());
+                propertyNamesHashMap.putIfAbsent(secretName.replaceAll("-", "."), s.id());
             });
 
             this.lastUpdateTime.set(System.currentTimeMillis());


### PR DESCRIPTION
* Replace '-' to '.' for all keyvault secrets.

Signed-off-by: Pan Li <panli@microsoft.com>
