### PR TITLE
Temp workaround to limits of Active Directory groups used for authori…

### DIFF
--- a/azure-spring-boot/src/main/resources/serviceEndpoints.properties
+++ b/azure-spring-boot/src/main/resources/serviceEndpoints.properties
@@ -1,9 +1,9 @@
 azure.service.endpoints.cn.aadSigninUri=https://login.partner.microsoftonline.cn/
 azure.service.endpoints.cn.aadGraphApiUri=https://graph.chinacloudapi.cn/
 azure.service.endpoints.cn.aadKeyDiscoveryUri=https://login.partner.microsoftonline.cn/common/discovery/keys
-azure.service.endpoints.cn.aadMembershipRestUri=https://graph.chinacloudapi.cn/me/memberOf?api-version=1.6
+azure.service.endpoints.cn.aadMembershipRestUri=https://graph.chinacloudapi.cn/me/memberOf?api-version=1.6&$top=999
 azure.service.endpoints.global.aadSigninUri=https://login.microsoftonline.com/
 azure.service.endpoints.global.aadGraphApiUri=https://graph.windows.net/
 azure.service.endpoints.global.aadKeyDiscoveryUri=https://login.microsoftonline.com/common/discovery/keys/
-azure.service.endpoints.global.aadMembershipRestUri=https://graph.windows.net/me/memberOf?api-version=1.6
+azure.service.endpoints.global.aadMembershipRestUri=https://graph.windows.net/me/memberOf?api-version=1.6&$top=999
 


### PR DESCRIPTION
…zation

Temporary workaround to bug 388 by increasing the limit of number of users returned by the API to 999 from 100.

## Summary
As described in bug #388, this is a temp work around to fix potential issues around authorization being limited to the membership of the first 100 groups that are returned by the Graph API.
 
## Issue Type
- Bug fixing

## Starter Names
  - active directory spring boot starter

## Additional Information