### PR TITLE
fix the tranvis bug that run the command fail because of the license …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - sudo apt-get -y install python3-pip python-dev


### PR DESCRIPTION
## Summary
fix the tranvis build fail problem

tranvis build failed because of the license of oraclejdk8.

## Issue Type
- Bug fixing

## Starter Names
none

## Additional Information
none