### PR TITLE
Fix MSI authentication for Key Vault

### DIFF
--- a/azure-spring-boot-bom/pom.xml
+++ b/azure-spring-boot-bom/pom.xml
@@ -138,6 +138,14 @@
                 <artifactId>azure-spring-boot</artifactId>
                 <version>${azure.spring.boot.version}</version>
             </dependency>
+
+
+            <!-- Azure Client Authentication -->
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-client-authentication</artifactId>
+                <version>1.6.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/azure-spring-boot-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-keyvault-secrets-spring-boot-starter/pom.xml
@@ -29,6 +29,12 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-client-runtime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorHelper.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorHelper.java
@@ -83,7 +83,16 @@ class KeyVaultEnvironmentPostProcessorHelper {
             LOG.debug("Will use MSI credentials for app services");
             final String msiEndpoint = getProperty(this.environment, "MSI_ENDPOINT");
             final String msiSecret = getProperty(this.environment, "MSI_SECRET");
-            return new AppServiceMSICredentials(AzureEnvironment.AZURE, msiEndpoint, msiSecret);
+            final AppServiceMSICredentials msiCredentials = new AppServiceMSICredentials(AzureEnvironment.AZURE,
+                    msiEndpoint, msiSecret);
+
+            if (this.environment.containsProperty(Constants.AZURE_KEYVAULT_CLIENT_ID)) {
+                LOG.debug("Will use MSI credentials for app services with user assigned identity");
+                final String clientId = getProperty(this.environment, Constants.AZURE_KEYVAULT_CLIENT_ID);
+                msiCredentials.withClientId(clientId);
+            }
+
+            return msiCredentials;
         }
 
         final long timeAcquiringTimeoutInSeconds = this.environment.getProperty(


### PR DESCRIPTION
Fix MSI authentication for Key Vault in App Services.

## Summary
1. Update azure-client-authentication for cases when user assigned identity used with App Services, to support client-id.
2. Update run-time version to fix HTTP 400 bad request.

## Issue Type
<!--Pick one below and delete the rest-->
- Bug fixing

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - key vault spring boot starter
 