### PR TITLE
Update Storage README.md to version 2.2.0.M1

### DIFF
--- a/azure-spring-boot-starters/azure-storage-spring-boot-starter/README.md
+++ b/azure-spring-boot-starters/azure-storage-spring-boot-starter/README.md
@@ -9,7 +9,7 @@ If you are using Maven, add the following dependency.
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-storage-spring-boot-starter</artifactId>
-    <version>2.0.5</version>
+    <version>2.2.0.M1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
The documentation uses version 2.0.5 which is older and hence updating the documentation with the latest version available in maven repository 2.2.0.M1

## Issue Type
- Documentation

## Starter Names
 - storage spring boot starter

## Additional Information
Version update in the README.md file documentation for fellow developers to use the latest releases