### PR TITLE
Updated cosmosdb starter

### DIFF
--- a/azure-spring-boot-samples/azure-cosmosdb-spring-boot-sample/pom.xml
+++ b/azure-spring-boot-samples/azure-cosmosdb-spring-boot-sample/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>io.projectreactor.netty</groupId>
-            <artifactId>reactor-netty</artifactId>
-            <version>0.8.3.RELEASE</version>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/azure-spring-boot-samples/azure-cosmosdb-spring-boot-sample/src/main/resources/application.properties
+++ b/azure-spring-boot-samples/azure-cosmosdb-spring-boot-sample/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 azure.cosmosdb.uri=put-your-cosmosdb-uri-here
 azure.cosmosdb.key=put-your-cosmosdb-key-here
 azure.cosmosdb.database=put-your-cosmosdb-databasename-here
+azure.cosmosdb.populateQueryMetrics=true

--- a/azure-spring-boot-tests/azure-spring-boot-test-cosmosdb/src/test/java/com/microsoft/azure/test/cosmosdb/CosmosDBTest.java
+++ b/azure-spring-boot-tests/azure-spring-boot-test-cosmosdb/src/test/java/com/microsoft/azure/test/cosmosdb/CosmosDBTest.java
@@ -61,6 +61,7 @@ public class CosmosDBTest {
             app.property("azure.cosmosdb.uri", endPoint);
             app.property("azure.cosmosdb.key", masterKey);
             app.property("azure.cosmosdb.database", cosmosdbTool.DATABASE_ID);
+            app.property("azure.cosmosdb.populateQueryMetrics", String.valueOf(true));
 
             //start app
             app.start();
@@ -78,6 +79,7 @@ public class CosmosDBTest {
             app.property("azure.cosmosdb.uri", endPoint);
             app.property("azure.cosmosdb.key", masterKey);
             app.property("azure.cosmosdb.database", cosmosdbTool.DATABASE_ID);
+            app.property("azure.cosmosdb.populateQueryMetrics", String.valueOf(true));
 
             //start app
             app.start();

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosAutoConfiguration.java
@@ -33,14 +33,15 @@ public class CosmosAutoConfiguration extends AbstractCosmosConfiguration {
 
     @Bean
     public CosmosDBConfig cosmosDBConfig() {
-        final CosmosDBConfig config = CosmosDBConfig.builder(
-                properties.getUri(), properties.getKey(), properties.getDatabase())
-                .consistencyLevel(properties.getConsistencyLevel())
-                .allowTelemetry(properties.isAllowTelemetry())
-                .connectionPolicy(properties.getConnectionPolicy())
-                .build();
 
-        return config;
+        return CosmosDBConfig.builder(
+                properties.getUri(), properties.getKey(), properties.getDatabase())
+                             .consistencyLevel(properties.getConsistencyLevel())
+                             .allowTelemetry(properties.isAllowTelemetry())
+                             .connectionPolicy(properties.getConnectionPolicy())
+                             .responseDiagnosticsProcessor(properties.getResponseDiagnosticsProcessor())
+                             .populateQueryMetrics(properties.isPopulateQueryMetrics())
+                             .build();
     }
 
     private void configConnectionPolicy(CosmosDBProperties properties, ConnectionPolicy connectionPolicy) {

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosDBProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosDBProperties.java
@@ -8,14 +8,16 @@ package com.microsoft.azure.spring.autoconfigure.cosmosdb;
 
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
-
-import javax.validation.constraints.NotEmpty;
-
+import com.microsoft.azure.spring.data.cosmosdb.core.ResponseDiagnosticsProcessor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import javax.validation.constraints.NotEmpty;
+
 @Validated
 @ConfigurationProperties("azure.cosmosdb")
+@Slf4j
 public class CosmosDBProperties {
     /**
      * Document DB URI.
@@ -41,9 +43,25 @@ public class CosmosDBProperties {
     private String database;
 
     /**
+     * Populate Diagnostics Strings and Query metrics
+     */
+    private boolean populateQueryMetrics;
+
+    /**
      * Whether allow Microsoft to collect telemetry data.
      */
     private boolean allowTelemetry = true;
+
+    /**
+     * Response Diagnostics processor
+     * Default implementation is to log the response diagnostics string
+     */
+    private ResponseDiagnosticsProcessor responseDiagnosticsProcessor =
+        responseDiagnostics -> {
+        if (populateQueryMetrics) {
+            log.info("Response Diagnostics {}", responseDiagnostics);
+        }
+    };
 
     private ConnectionPolicy connectionPolicy = ConnectionPolicy.defaultPolicy();
 
@@ -93,5 +111,21 @@ public class CosmosDBProperties {
 
     public void setConnectionPolicy(ConnectionPolicy connectionPolicy) {
         this.connectionPolicy = connectionPolicy;
+    }
+
+    public boolean isPopulateQueryMetrics() {
+        return populateQueryMetrics;
+    }
+
+    public void setPopulateQueryMetrics(boolean populateQueryMetrics) {
+        this.populateQueryMetrics = populateQueryMetrics;
+    }
+
+    public ResponseDiagnosticsProcessor getResponseDiagnosticsProcessor() {
+        return responseDiagnosticsProcessor;
+    }
+
+    public void setResponseDiagnosticsProcessor(ResponseDiagnosticsProcessor responseDiagnosticsProcessor) {
+        this.responseDiagnosticsProcessor = responseDiagnosticsProcessor;
     }
 }

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosDBPropertiesTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosDBPropertiesTest.java
@@ -35,6 +35,7 @@ public class CosmosDBPropertiesTest {
             assertThat(properties.getKey()).isEqualTo(PropertySettingUtil.KEY);
             assertThat(properties.getConsistencyLevel()).isEqualTo(PropertySettingUtil.CONSISTENCY_LEVEL);
             assertThat(properties.isAllowTelemetry()).isEqualTo(PropertySettingUtil.ALLOW_TELEMETRY_TRUE);
+            assertThat(properties.isPopulateQueryMetrics()).isEqualTo(PropertySettingUtil.POPULATE_QUERY_METRICS);
         }
 
         PropertySettingUtil.unsetProperties();

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/PropertySettingUtil.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/PropertySettingUtil.java
@@ -18,6 +18,7 @@ public class PropertySettingUtil {
     public static final String DATABASE_NAME = "test";
     public static final boolean ALLOW_TELEMETRY_TRUE = true;
     public static final boolean ALLOW_TELEMETRY_FALSE = false;
+    public static final boolean POPULATE_QUERY_METRICS = true;
     public static final ConsistencyLevel CONSISTENCY_LEVEL = ConsistencyLevel.STRONG;
     public static final int REQUEST_TIMEOUT = 4;
     public static final int MEDIA_REQUEST_TIMEOUT = 3;
@@ -35,6 +36,7 @@ public class PropertySettingUtil {
     private static final String PROPERTY_DBNAME = "azure.cosmosdb.database";
     private static final String PROPERTY_CONSISTENCY_LEVEL = "azure.cosmosdb.consistency-level";
     private static final String PROPERTY_ALLOW_TELEMETRY = "azure.cosmosdb.allow-telemetry";
+    private static final String PROPERTY_POPULATE_QUERY_METRICS = "azure.cosmosdb.populateQueryMetrics";
 
     public static void setProperties() {
         System.setProperty(PROPERTY_URI, URI);
@@ -42,6 +44,7 @@ public class PropertySettingUtil {
         System.setProperty(PROPERTY_DBNAME, DATABASE_NAME);
         System.setProperty(PROPERTY_CONSISTENCY_LEVEL, CONSISTENCY_LEVEL.name());
         System.setProperty(PROPERTY_ALLOW_TELEMETRY, Boolean.toString(ALLOW_TELEMETRY_TRUE));
+        System.setProperty(PROPERTY_POPULATE_QUERY_METRICS, Boolean.toString(POPULATE_QUERY_METRICS));
     }
 
     public static void setAllowTelemetryFalse() {
@@ -55,6 +58,7 @@ public class PropertySettingUtil {
         System.clearProperty(PROPERTY_DBNAME);
         System.clearProperty(PROPERTY_CONSISTENCY_LEVEL);
         System.clearProperty(PROPERTY_ALLOW_TELEMETRY);
+        System.clearProperty(PROPERTY_POPULATE_QUERY_METRICS);
     }
 
     public static void unsetAllowTelemetry() {


### PR DESCRIPTION
## Summary
Updated Cosmos DB starter to include query metrics and response diagnostics string.
Removed reactor-netty dependency. 

## Issue Type
- New Feature

## Starter Names
  - cosmosdb spring boot starter

## Additional Information
Updated application.properties to reflect populateQueryMetrics field value. 