### PR TITLE
Add support for JDK9+ in build process.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
     mavenPomFile: 'pom.xml'
     mavenOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.8'
+    jdkVersionOption: '1.11'
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'
@@ -43,7 +43,7 @@ steps:
     gradleWrapperFile: 'azure-spring-boot-samples/gradlew'
     workingDirectory: 'azure-spring-boot-samples'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.8'
+    jdkVersionOption: '1.11'
     jdkArchitectureOption: 'x64'
     publishJUnitResults: false
     tasks: 'build'

--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -23,10 +23,12 @@
         module pom file -->
         <project.rootdir>${project.basedir}/..</project.rootdir>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+
         <spring.boot.version>2.2.0.RELEASE</spring.boot.version>
         <spring.springframework.version>5.2.0.RELEASE</spring.springframework.version>
         <findbugs.annotations.version>2.0.1</findbugs.annotations.version>
@@ -61,6 +63,26 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>${java.version}</maven.compiler.release>
+                <javadocExecutable>${java.home}/bin/</javadocExecutable>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>(,9)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>${java.version}</maven.compiler.source>
+                <maven.compiler.target>${java.version}</maven.compiler.target>
+            </properties>
         </profile>
     </profiles>
 
@@ -158,6 +180,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -213,23 +240,16 @@
                 <inherited>true</inherited>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.12.2</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
-                    <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/findbugs</spotbugsXmlOutputDirectory>
                     <excludeFilterFile>${project.rootdir}/config/findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>1.9.4</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <phase>compile</phase>
@@ -240,27 +260,51 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>prepare-ut-agent</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>com/microsoft/azure/spring/boot/autoconfigure/common/GetHashMac.class</exclude>
+                                <exclude>com/microsoft/azure/**/Constants.class</exclude>
+                                <exclude>com/microsoft/azure/**/AzureADJwtTokenFilter.class</exclude>
+                                <exclude>com/microsoft/azure/**/Userprincipal.class</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>false</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>65%</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check>
-                        <haltOnFailure>true</haltOnFailure>
-                        <branchRate>65</branchRate>
-                        <totalBranchRate>65</totalBranchRate>
-                    </check>
-                    <instrumentation>
-                        <excludes>
-                            <exclude>com/microsoft/azure/spring/boot/autoconfigure/common/GetHashMac.class</exclude>
-                            <exclude>com/microsoft/azure/**/Constants.class</exclude>
-                            <exclude>com/microsoft/azure/**/AzureADJwtTokenFilter.class</exclude>
-                            <exclude>com/microsoft/azure/**/Userprincipal.class</exclude>
-                        </excludes>
-                    </instrumentation>
+                    <skip>${skipTests}</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/azure-spring-boot-samples/pom.xml
+++ b/azure-spring-boot-samples/pom.xml
@@ -108,24 +108,16 @@
                 <inherited>true</inherited>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.12.2</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
-                    <findbugsXmlOutputDirectory>${project.build.directory}/findbugs
-                    </findbugsXmlOutputDirectory>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/findbugs</spotbugsXmlOutputDirectory>
                     <excludeFilterFile>${project.rootdir}/config/findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>1.9.4</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <phase>compile</phase>

--- a/azure-spring-boot-tests/azure-spring-boot-test-core/pom.xml
+++ b/azure-spring-boot-tests/azure-spring-boot-test-core/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.cobertura</groupId>
-            <artifactId>cobertura</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
         </dependency>

--- a/azure-spring-boot-tests/pom.xml
+++ b/azure-spring-boot-tests/pom.xml
@@ -24,18 +24,40 @@
         <!-- For module that has different relative path to the root dir, project.rootdir should be redefined
         in its module pom file -->
         <project.rootdir>${project.basedir}/..</project.rootdir>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>8</java.version>
+
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
 
         <spring.boot.version>2.2.0.RELEASE</spring.boot.version>
         <azure.spring.boot.version>2.2.1-SNAPSHOT</azure.spring.boot.version>
         <azure.mgmt.version>1.26.0</azure.mgmt.version>
-        <cobertura.version>2.1.1</cobertura.version>
         <secure.channel.version>0.1.53</secure.channel.version>
         <expect4j.version>1.6</expect4j.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>${java.version}</maven.compiler.release>
+                <javadocExecutable>${java.home}/bin/</javadocExecutable>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>(,9)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>${java.version}</maven.compiler.source>
+                <maven.compiler.target>${java.version}</maven.compiler.target>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencyManagement>
         <dependencies>
@@ -54,13 +76,6 @@
                 <version>${azure.spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>net.sourceforge.cobertura</groupId>
-                <artifactId>cobertura</artifactId>
-                <version>${cobertura.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -102,6 +117,11 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven-failsafe-plugin.version}</version>
                 </plugin>
@@ -135,24 +155,16 @@
                 <inherited>true</inherited>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.12.2</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
-                    <findbugsXmlOutputDirectory>${project.build.directory}/findbugs
-                    </findbugsXmlOutputDirectory>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/findbugs</spotbugsXmlOutputDirectory>
                     <excludeFilterFile>${project.rootdir}/config/findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>1.9.4</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <phase>compile</phase>
@@ -161,6 +173,46 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>prepare-it-agent</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report-it</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>report-integration</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>false</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>65%</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -1,14 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<FindBugsFilter>
-    <Class name="com.microsoft.azure.spring.support.GetHashMac"/>
-    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
-    <Bug pattern="Unwritten field"/>
-    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
-    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS"/>
-    <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"/>
-    <Bug pattern="RE_POSSIBLE_UNINTENDED_PATTERN"/>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.1/spotbugs/etc/findbugsfilter.xsd">
 
-    <Class name="com.microsoft.azure.telemetry.TelemetrySender"/>
-    <Bug pattern="REC_CATCH_EXCEPTION"/>
+    <Match>
+        <Class name="com.microsoft.azure.spring.support.GetHashMac"/>
+        <Or>
+            <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+            <Bug pattern="Unwritten field"/>
+            <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
+            <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS"/>
+            <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"/>
+            <Bug pattern="RE_POSSIBLE_UNINTENDED_PATTERN"/>
+            <Bug pattern="DM_CONVERT_CASE"/>
+            <Bug pattern="DM_DEFAULT_ENCODING"/>
+        </Or>
+    </Match>
+
+    <Match>
+        <Class name="com.microsoft.azure.telemetry.TelemetrySender"/>
+        <Bug pattern="REC_CATCH_EXCEPTION"/>
+    </Match>
+
+    <!-- Workaround for JDK11 https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Match>
+        <Or>
+            <BugPattern name="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+            <BugPattern name="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/travis-wait-mvn-build.sh
+++ b/travis-wait-mvn-build.sh
@@ -6,5 +6,3 @@ function write_visual_bells() {
   done
 }
 write_visual_bells&
-
-set -o pipefail && mvn cobertura:cobertura verify | grep -v "DEBUG"


### PR DESCRIPTION
## Summary
Adds additional support to compile the project with JDK9+.
Since Azure WebApps officially supports JRE11 it makes sense to compile and test the libraries with JDK11 in Java 8 compatibility-mode.

## Issue Type
- New Feature

## Starter Names
- No code changes involved

## Additional Information