### PR TITLE
configurable connection policy

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosDBProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/cosmosdb/CosmosDBProperties.java
@@ -63,7 +63,7 @@ public class CosmosDBProperties {
         }
     };
 
-    private ConnectionPolicy connectionPolicy = ConnectionPolicy.defaultPolicy();
+    private ConnectionPolicy connectionPolicy;
 
     public String getUri() {
         return uri;
@@ -106,6 +106,9 @@ public class CosmosDBProperties {
     }
 
     public ConnectionPolicy getConnectionPolicy() {
+        if (null == connectionPolicy) {
+            return ConnectionPolicy.defaultPolicy();
+        }
         return connectionPolicy;
     }
 


### PR DESCRIPTION
## Summary
Currently the connection policy(com.azure.data.cosmos.ConnectionPolicy) cannot be specified for CosmosDBProperties. If there is a need to set connectionMode in ConnectionPolicy (maybe ConnectionMode.GATEWAY) for a connection, it is not possible as the getter always returns the statically created connectionPolicy

##Resolution
By Changing the getter code to return the actual value, it can be resolved
