### PR TITLE
support specifying custom authority in AzureADGraphClient via properties

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationProperties.java
@@ -33,6 +33,10 @@ public class AADAuthenticationProperties {
      */
     private UserGroupProperties userGroup = new UserGroupProperties();
 
+    /**
+     * Leave blank for default (usually: "https://login.microsoftonline.com/common/")
+     */
+    private String authority;
 
     /**
      * Azure service environment/region name, e.g., cn, global

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -16,6 +16,7 @@ import com.microsoft.aad.msal4j.OnBehalfOfParameters;
 import com.microsoft.aad.msal4j.UserAssertion;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -199,8 +200,12 @@ public class AzureADGraphClient {
         try {
             service = Executors.newFixedThreadPool(1);
 
-            final ConfidentialClientApplication application = ConfidentialClientApplication.builder(clientId,
-                    clientCredential).build();
+            final ConfidentialClientApplication.Builder builder = ConfidentialClientApplication.builder(clientId,
+                    clientCredential);
+            if (StringUtils.isNotBlank(aadAuthenticationProperties.getAuthority())) {
+                builder.authority(aadAuthenticationProperties.getAuthority());
+            }
+            final ConfidentialClientApplication application = builder.build();
 
             final Set<String> scopes = new HashSet<>();
             scopes.add(aadMicrosoftGraphApiBool ? MICROSOFT_GRAPH_SCOPE : AAD_GRAPH_API_SCOPE);


### PR DESCRIPTION
## Summary
Currently the `AzureADGraphClient` always uses the default authority (hard-coded in msal4j to be "https://login.microsoftonline.com/common/") no matter of your configured tenant, token-uri or other endpoints!

This patch fixes this to be configurable via properties.

## Issue Type
- Bug fixing

## Starter Names
  - active directory spring boot starter

## Additional Information
To change it in your app, add the following to your application.properties:
`azure.activedirectory.authority=https://login.microsoftonline.com/your-tenant-id/`