### PR TITLE
fix regression of AAD authority

### DIFF
--- a/azure-spring-boot-tests/azure-spring-boot-test-aad/src/test/java/com/microsoft/azure/test/keyvault/approle/AADAppRoleStatelessAuthenticationFilterIT.java
+++ b/azure-spring-boot-tests/azure-spring-boot-test-aad/src/test/java/com/microsoft/azure/test/keyvault/approle/AADAppRoleStatelessAuthenticationFilterIT.java
@@ -33,6 +33,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 
 import static com.microsoft.azure.test.oauth.OAuthUtils.AAD_CLIENT_ID;
+import static com.microsoft.azure.test.oauth.OAuthUtils.AAD_CLIENT_SECRET;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -44,7 +45,8 @@ public class AADAppRoleStatelessAuthenticationFilterIT {
     @Test
     @Ignore
     public void testAADAppRoleStatelessAuthenticationFilter() {
-        final OAuthResponse authResponse = OAuthUtils.executeOAuth2ROPCFlow();
+        final OAuthResponse authResponse = OAuthUtils.executeOAuth2ROPCFlow(System.getenv(AAD_CLIENT_ID),
+                System.getenv(AAD_CLIENT_SECRET));
         assertNotNull(authResponse);
 
         try (AppRunner app = new AppRunner(DumbApp.class)) {

--- a/azure-spring-boot-tests/azure-spring-boot-test-aad/src/test/java/com/microsoft/azure/test/keyvault/group/AADAuthenticationFilterIT.java
+++ b/azure-spring-boot-tests/azure-spring-boot-test-aad/src/test/java/com/microsoft/azure/test/keyvault/group/AADAuthenticationFilterIT.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 
 import static com.microsoft.azure.test.oauth.OAuthUtils.AAD_CLIENT_ID;
 import static com.microsoft.azure.test.oauth.OAuthUtils.AAD_CLIENT_SECRET;
+import static com.microsoft.azure.test.oauth.OAuthUtils.SINGLE_TENANT_AAD_CLIENT_ID;
+import static com.microsoft.azure.test.oauth.OAuthUtils.SINGLE_TENANT_AAD_CLIENT_SECRET;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.http.HttpHeaders.COOKIE;
@@ -48,14 +50,25 @@ public class AADAuthenticationFilterIT {
     private RestTemplate restTemplate = new RestTemplate();
 
     @Test
-    public void testAADAuthenticationFilter() {
-        final OAuthResponse authResponse = OAuthUtils.executeOAuth2ROPCFlow();
+    public void testAADAuthenticationFilterWithSingleTenantApp() {
+        testAADAuthenticationFilter(System.getenv(SINGLE_TENANT_AAD_CLIENT_ID),
+                System.getenv(SINGLE_TENANT_AAD_CLIENT_SECRET));
+    }
+
+    @Test
+    public void testAADAuthenticationFilterWithMultiTenantApp() {
+        testAADAuthenticationFilter(System.getenv(AAD_CLIENT_ID), System.getenv(AAD_CLIENT_SECRET));
+    }
+
+
+    private void testAADAuthenticationFilter(String clientId, String clientSecret) {
+        final OAuthResponse authResponse = OAuthUtils.executeOAuth2ROPCFlow(clientId, clientSecret);
         assertNotNull(authResponse);
 
         try (AppRunner app = new AppRunner(DumbApp.class)) {
 
-            app.property("azure.activedirectory.client-id", System.getenv(AAD_CLIENT_ID));
-            app.property("azure.activedirectory.client-secret", System.getenv(AAD_CLIENT_SECRET));
+            app.property("azure.activedirectory.client-id", clientId);
+            app.property("azure.activedirectory.client-secret", clientSecret);
             app.property("azure.activedirectory.ActiveDirectoryGroups", "group1,group2");
 
             app.start();

--- a/azure-spring-boot-tests/azure-spring-boot-test-aad/src/test/java/com/microsoft/azure/test/oauth/OAuthUtils.java
+++ b/azure-spring-boot-tests/azure-spring-boot-test-aad/src/test/java/com/microsoft/azure/test/oauth/OAuthUtils.java
@@ -20,6 +20,8 @@ public class OAuthUtils {
 
     public static final String AAD_CLIENT_ID = "AAD_CLIENT_ID";
     public static final String AAD_CLIENT_SECRET = "AAD_CLIENT_SECRET";
+    public static final String SINGLE_TENANT_AAD_CLIENT_ID = "SINGLE_TENANT_AAD_CLIENT_ID";
+    public static final String SINGLE_TENANT_AAD_CLIENT_SECRET = "SINGLE_TENANT_AAD_CLIENT_SECRET";
     private static final String AAD_TENANT_ID = "AAD_TENANT_ID";
     private static final String AAD_USER_NAME = "AAD_USER_NAME";
     private static final String AAD_USER_PASSWORD = "AAD_USER_PASSWORD";
@@ -27,15 +29,13 @@ public class OAuthUtils {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final OkHttpClient client = new OkHttpClient();
 
-    public static OAuthResponse executeOAuth2ROPCFlow() {
+    public static OAuthResponse executeOAuth2ROPCFlow(String aadClientId, String aadClientSecret) {
         final MediaType mediaType = MediaType.parse("application/x-www-form-urlencoded");
-        final String aadClientId = System.getenv(AAD_CLIENT_ID);
-        final String aadClientSecret = System.getenv(AAD_CLIENT_SECRET);
         final String aadUsername = System.getenv(AAD_USER_NAME);
         final String aadUserPassword = System.getenv(AAD_USER_PASSWORD);
 
-        assertNotEmpty(aadClientId, AAD_CLIENT_ID);
-        assertNotEmpty(aadClientSecret, AAD_CLIENT_SECRET);
+        assertNotEmpty(aadClientId, "client id");
+        assertNotEmpty(aadClientSecret, "client secret");
         assertNotEmpty(aadUsername, AAD_USER_NAME);
         assertNotEmpty(aadUserPassword, AAD_USER_PASSWORD);
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AzureADGraphClient.java
@@ -199,8 +199,10 @@ public class AzureADGraphClient {
         try {
             service = Executors.newFixedThreadPool(1);
 
-            final ConfidentialClientApplication application = ConfidentialClientApplication.builder(clientId,
-                    clientCredential).build();
+            final ConfidentialClientApplication application = ConfidentialClientApplication
+                    .builder(clientId, clientCredential)
+                    .authority(serviceEndpoints.getAadSigninUri() + tenantId + "/")
+                    .build();
 
             final Set<String> scopes = new HashSet<>();
             scopes.add(aadMicrosoftGraphApiBool ? MICROSOFT_GRAPH_SCOPE : AAD_GRAPH_API_SCOPE);


### PR DESCRIPTION
## Summary
<!--Describe the change berifly-->
AAD authority is not correctly set causing failing to acquire ID token via a single-tenant application.

## Issue Type
<!--Pick one below and delete the rest-->
- Bug fixing

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - active directory spring boot starter

## Additional Information