### PR TITLE
Prepend application id to User-Agent header

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
@@ -25,4 +25,10 @@ public class Constants {
 
     public static final long DEFAULT_REFRESH_INTERVAL_MS = 1800000L;
     public static final long TOKEN_ACQUIRE_TIMEOUT_SECS = 60L;
+
+    // for the User-Agent header set in track2 SDKs
+    public static final String SPRINGBOOT_VERSION = "2.2.4-SNAPSHOT";
+    public static final String SPRINGBOOT_KEY_VAULT_APPLICATION_ID = "az-springboot-keyvault/" +
+            SPRINGBOOT_VERSION;
+
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
@@ -27,8 +27,14 @@ public class Constants {
     public static final long TOKEN_ACQUIRE_TIMEOUT_SECS = 60L;
 
     // for the User-Agent header set in track2 SDKs
-    public static final String SPRINGBOOT_VERSION = "snapshot";
-    public static final String SPRINGBOOT_KEY_VAULT_APPLICATION_ID = "az-sb-kv/" +
-            SPRINGBOOT_VERSION;
+    private static final String SNAPSHOT_VERSION = "snapshot";
+    private static final String AZURE = "az";
+    private static final String SPRING = "sp";
+    private static final String KEY_VAULT = "kv";
+
+    public static final String SPRINGBOOT_VERSION = SNAPSHOT_VERSION;
+    // the max length of application id is 24
+    public static final String SPRINGBOOT_KEY_VAULT_APPLICATION_ID =
+            String.join("-", AZURE, SPRING, KEY_VAULT) + "/" + SPRINGBOOT_VERSION;
 
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
@@ -27,8 +27,8 @@ public class Constants {
     public static final long TOKEN_ACQUIRE_TIMEOUT_SECS = 60L;
 
     // for the User-Agent header set in track2 SDKs
-    public static final String SPRINGBOOT_VERSION = "2.2.4-SNAPSHOT";
-    public static final String SPRINGBOOT_KEY_VAULT_APPLICATION_ID = "az-springboot-keyvault/" +
+    public static final String SPRINGBOOT_VERSION = "2.2.5-SNAP";
+    public static final String SPRINGBOOT_KEY_VAULT_APPLICATION_ID = "az-sb-kv/" +
             SPRINGBOOT_VERSION;
 
 }

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
     public static final long TOKEN_ACQUIRE_TIMEOUT_SECS = 60L;
 
     // for the User-Agent header set in track2 SDKs
-    public static final String SPRINGBOOT_VERSION = "2.2.5-SNAP";
+    public static final String SPRINGBOOT_VERSION = "snapshot";
     public static final String SPRINGBOOT_KEY_VAULT_APPLICATION_ID = "az-sb-kv/" +
             SPRINGBOOT_VERSION;
 

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorHelper.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/keyvault/spring/KeyVaultEnvironmentPostProcessorHelper.java
@@ -7,6 +7,7 @@
 package com.microsoft.azure.keyvault.spring;
 
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.identity.ClientCertificateCredentialBuilder;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
@@ -15,7 +16,6 @@ import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.microsoft.azure.telemetry.TelemetrySender;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.microsoft.azure.keyvault.spring.Constants.SPRINGBOOT_KEY_VAULT_APPLICATION_ID;
 import static com.microsoft.azure.telemetry.TelemetryData.SERVICE_NAME;
 import static com.microsoft.azure.telemetry.TelemetryData.getClassPackageSimpleName;
 
@@ -58,6 +59,7 @@ class KeyVaultEnvironmentPostProcessorHelper {
         final SecretClient secretClient = new SecretClientBuilder()
                 .vaultUrl(vaultUri)
                 .credential(tokenCredential)
+                .httpLogOptions(new HttpLogOptions().setApplicationId(SPRINGBOOT_KEY_VAULT_APPLICATION_ID))
                 .buildClient();
         try {
             final MutablePropertySources sources = this.environment.getPropertySources();

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/utils/ApplicationIdTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/utils/ApplicationIdTest.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.microsoft.azure.keyvault.spring.Constants.SPRINGBOOT_KEY_VAULT_APPLICATION_ID;
+
+public class ApplicationIdTest {
+
+    @Test
+    public void maxLength() {
+        Assert.assertTrue(SPRINGBOOT_KEY_VAULT_APPLICATION_ID.length() <= 24);
+    }
+
+}


### PR DESCRIPTION
## Summary
Prepend application id to the User-Agent header when using track2 libraries.

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - key vault spring boot starter

## Additional Information