### PR TITLE
Port #872 to 2.1.x

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAppRoleStatelessAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAppRoleStatelessAuthenticationFilter.java
@@ -52,27 +52,8 @@ public class AADAppRoleStatelessAuthenticationFilter extends OncePerRequestFilte
         final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
         boolean cleanupRequired = false;
 
-        if (hasText(authHeader) && authHeader.startsWith(TOKEN_TYPE)) {
-            try {
-                final String token = authHeader.replace(TOKEN_TYPE, "");
-                final UserPrincipal principal = principalManager.buildUserPrincipal(token);
-                final JSONArray roles = Optional.ofNullable((JSONArray) principal.getClaims().get("roles"))
-                    .filter(r -> !r.isEmpty())
-                    .orElse(DEFAULT_ROLE_CLAIM);
-                final Authentication authentication = new PreAuthenticatedAuthenticationToken(
-                    principal, null, rolesToGrantedAuthorities(roles));
-                authentication.setAuthenticated(true);
-                log.info("Request token verification success. {}", authentication);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-                cleanupRequired = true;
-            } catch (BadJWTException ex) {
-                final String errorMessage = "Invalid JWT. Either expired or not yet valid. " + ex.getMessage();
-                log.warn(errorMessage);
-                throw new ServletException(errorMessage, ex);
-            } catch (ParseException | BadJOSEException | JOSEException ex) {
-                log.error("Failed to initialize UserPrincipal.", ex);
-                throw new ServletException(ex);
-            }
+        if (!alreadyAuthenticated() && hasText(authHeader) && authHeader.startsWith(TOKEN_TYPE)) {
+            cleanupRequired = verifyToken(authHeader.replace(TOKEN_TYPE, ""));
         }
 
         try {
@@ -83,6 +64,39 @@ public class AADAppRoleStatelessAuthenticationFilter extends OncePerRequestFilte
                 SecurityContextHolder.clearContext();
             }
         }
+    }
+
+    private boolean verifyToken(String token) throws ServletException {
+        if (!principalManager.isTokenIssuedByAAD(token)) {
+            log.info("Token {} is not issued by AAD", token);
+            return false;
+        }
+
+        try {
+            final UserPrincipal principal = principalManager.buildUserPrincipal(token);
+            final JSONArray roles = Optional.ofNullable((JSONArray) principal.getClaims().get("roles"))
+                    .filter(r -> !r.isEmpty())
+                    .orElse(DEFAULT_ROLE_CLAIM);
+
+            final Authentication authentication = new PreAuthenticatedAuthenticationToken(
+                    principal, null, rolesToGrantedAuthorities(roles));
+            authentication.setAuthenticated(true);
+            log.info("Request token verification success. {}", authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            return true;
+        } catch (BadJWTException ex) {
+            final String errorMessage = "Invalid JWT. Either expired or not yet valid. " + ex.getMessage();
+            log.warn(errorMessage);
+            throw new ServletException(errorMessage, ex);
+        } catch (ParseException | BadJOSEException | JOSEException ex) {
+            log.error("Failed to initialize UserPrincipal.", ex);
+            throw new ServletException(ex);
+        }
+    }
+
+    private boolean alreadyAuthenticated() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.isAuthenticated();
     }
 
     protected Set<SimpleGrantedAuthority> rolesToGrantedAuthorities(JSONArray roles) {

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.naming.ServiceUnavailableException;
@@ -22,6 +23,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.text.ParseException;
@@ -43,22 +45,29 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
     public AADAuthenticationFilter(AADAuthenticationProperties aadAuthProps,
                                    ServiceEndpointsProperties serviceEndpointsProps,
                                    ResourceRetriever resourceRetriever) {
-        this.aadAuthProps = aadAuthProps;
-        this.serviceEndpointsProps = serviceEndpointsProps;
-        this.principalManager = new UserPrincipalManager(serviceEndpointsProps, aadAuthProps, resourceRetriever, false);
+        this(aadAuthProps, serviceEndpointsProps, new UserPrincipalManager(serviceEndpointsProps,
+                aadAuthProps,
+                resourceRetriever,
+                false));
     }
     
     public AADAuthenticationFilter(AADAuthenticationProperties aadAuthProps,
                                    ServiceEndpointsProperties serviceEndpointsProps,
                                    ResourceRetriever resourceRetriever,
                                    JWKSetCache jwkSetCache) {
-        this.aadAuthProps = aadAuthProps;
-        this.serviceEndpointsProps = serviceEndpointsProps;
-        this.principalManager = new UserPrincipalManager(serviceEndpointsProps,
+        this(aadAuthProps, serviceEndpointsProps, new UserPrincipalManager(serviceEndpointsProps,
                 aadAuthProps,
                 resourceRetriever,
                 false,
-                jwkSetCache);
+                jwkSetCache));
+    }
+
+    public AADAuthenticationFilter(AADAuthenticationProperties aadAuthProps,
+                                   ServiceEndpointsProperties serviceEndpointsProps,
+                                   UserPrincipalManager userPrincipalManager) {
+        this.aadAuthProps = aadAuthProps;
+        this.serviceEndpointsProps = serviceEndpointsProps;
+        this.principalManager = userPrincipalManager;
     }
 
     @Override
@@ -66,57 +75,63 @@ public class AADAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         final String authHeader = request.getHeader(TOKEN_HEADER);
 
-        if (authHeader != null && authHeader.startsWith(TOKEN_TYPE)) {
-            try {
-                final String idToken = authHeader.replace(TOKEN_TYPE, "");
-                UserPrincipal principal = (UserPrincipal) request
-                        .getSession().getAttribute(CURRENT_USER_PRINCIPAL);
-                String graphApiToken = (String) request
-                        .getSession().getAttribute(CURRENT_USER_PRINCIPAL_GRAPHAPI_TOKEN);
-                final String currentToken = (String) request
-                        .getSession().getAttribute(CURRENT_USER_PRINCIPAL_JWT_TOKEN);
-
-                final AzureADGraphClient client = new AzureADGraphClient(aadAuthProps.getClientId(),
-                        aadAuthProps.getClientSecret(), aadAuthProps, serviceEndpointsProps);
-
-                if (principal == null ||
-                    graphApiToken == null ||
-                    graphApiToken.isEmpty() ||
-                    !idToken.equals(currentToken)
-                ) {
-                    principal = principalManager.buildUserPrincipal(idToken);
-
-                    final String tenantId = principal.getClaim().toString();
-                    graphApiToken = client.acquireTokenForGraphApi(idToken, tenantId).accessToken();
-
-                    principal.setUserGroups(client.getGroups(graphApiToken));
-
-                    request.getSession().setAttribute(CURRENT_USER_PRINCIPAL, principal);
-                    request.getSession().setAttribute(CURRENT_USER_PRINCIPAL_GRAPHAPI_TOKEN, graphApiToken);
-                    request.getSession().setAttribute(CURRENT_USER_PRINCIPAL_JWT_TOKEN, idToken);
-                }
-
-                final Authentication authentication = new PreAuthenticatedAuthenticationToken(
-                        principal, null, client.convertGroupsToGrantedAuthorities(principal.getUserGroups()));
-
-                authentication.setAuthenticated(true);
-                log.info("Request token verification success. {}", authentication);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } catch (MalformedURLException | ParseException | BadJOSEException | JOSEException ex) {
-                log.error("Failed to initialize UserPrincipal.", ex);
-                throw new ServletException(ex);
-            } catch (ServiceUnavailableException ex) {
-                log.error("Failed to acquire graph api token.", ex);
-                throw new ServletException(ex);
-            } catch (MsalServiceException ex) {
-                if (ex.claims() != null && !ex.claims().isEmpty()) {
-                    throw new ServletException("Handle conditional access policy", ex);
-                } else {
-                    throw ex;
-                }
-            }
+        if (!alreadyAuthenticated() && authHeader != null && authHeader.startsWith(TOKEN_TYPE)) {
+            verifyToken(request.getSession(), authHeader.replace(TOKEN_TYPE, ""));
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean alreadyAuthenticated() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.isAuthenticated();
+    }
+
+    private void verifyToken(HttpSession session, String token) throws IOException, ServletException {
+        if (!principalManager.isTokenIssuedByAAD(token)) {
+            log.info("Token {} is not issued by AAD", token);
+            return;
+        }
+
+        try {
+            final String currentToken = (String) session.getAttribute(CURRENT_USER_PRINCIPAL_JWT_TOKEN);
+            UserPrincipal principal = (UserPrincipal) session.getAttribute(CURRENT_USER_PRINCIPAL);
+            String graphApiToken = (String) session.getAttribute(CURRENT_USER_PRINCIPAL_GRAPHAPI_TOKEN);
+
+            final AzureADGraphClient client = new AzureADGraphClient(aadAuthProps.getClientId(),
+                    aadAuthProps.getClientSecret(), aadAuthProps, serviceEndpointsProps);
+
+            if (principal == null || graphApiToken == null || graphApiToken.isEmpty() || !token.equals(currentToken)) {
+                principal = principalManager.buildUserPrincipal(token);
+
+                final String tenantId = principal.getClaim().toString();
+                graphApiToken = client.acquireTokenForGraphApi(token, tenantId).accessToken();
+
+                principal.setUserGroups(client.getGroups(graphApiToken));
+
+                session.setAttribute(CURRENT_USER_PRINCIPAL, principal);
+                session.setAttribute(CURRENT_USER_PRINCIPAL_GRAPHAPI_TOKEN, graphApiToken);
+                session.setAttribute(CURRENT_USER_PRINCIPAL_JWT_TOKEN, token);
+            }
+
+            final Authentication authentication = new PreAuthenticatedAuthenticationToken(
+                    principal, null, client.convertGroupsToGrantedAuthorities(principal.getUserGroups()));
+
+            authentication.setAuthenticated(true);
+            log.info("Request token verification success. {}", authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (MalformedURLException | ParseException | BadJOSEException | JOSEException ex) {
+            log.error("Failed to initialize UserPrincipal.", ex);
+            throw new ServletException(ex);
+        } catch (ServiceUnavailableException ex) {
+            log.error("Failed to acquire graph api token.", ex);
+            throw new ServletException(ex);
+        } catch (MsalServiceException ex) {
+            if (ex.claims() != null && !ex.claims().isEmpty()) {
+                throw new ServletException("Handle conditional access policy", ex);
+            } else {
+                throw ex;
+            }
+        }
     }
 }

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilterTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/aad/AADAuthenticationFilterTest.java
@@ -5,30 +5,53 @@
  */
 package com.microsoft.azure.spring.autoconfigure.aad;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.proc.BadJOSEException;
 import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.text.ParseException;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class AADAuthenticationFilterTest {
+
+    private static final String TOKEN = "dummy-token";
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(AADAuthenticationFilterAutoConfiguration.class));
+    private final UserPrincipalManager userPrincipalManager;
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final AADAuthenticationFilter filter;
 
-    @Before
+    public AADAuthenticationFilterTest() {
+        userPrincipalManager = mock(UserPrincipalManager.class);
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        filter = new AADAuthenticationFilter(mock(AADAuthenticationProperties.class),
+                mock(ServiceEndpointsProperties.class),
+                userPrincipalManager);
+    }
+
     @Ignore
     public void beforeEveryMethod() {
         Assume.assumeTrue(!Constants.CLIENT_ID.contains("real_client_id"));
@@ -79,6 +102,40 @@ public class AADAuthenticationFilterTest {
             assertThat(claims.get("iss")).isEqualTo(principal.getIssuer());
             assertThat(claims.get("sub")).isEqualTo(principal.getSubject());
         });
+    }
+
+    @Test
+    public void testTokenNotIssuedByAAD() throws ServletException, IOException {
+        when(userPrincipalManager.isTokenIssuedByAAD(TOKEN)).thenReturn(false);
+
+        final FilterChain filterChain = (request, response) -> {
+            final SecurityContext context = SecurityContextHolder.getContext();
+            assertNotNull(context);
+            final Authentication authentication = context.getAuthentication();
+            assertNull(authentication);
+        };
+
+        filter.doFilterInternal(request, response, filterChain);
+    }
+
+    @Test
+    public void testAlreadyAuthenticated() throws ServletException, IOException, ParseException, JOSEException,
+            BadJOSEException {
+        final Authentication authentication = mock(Authentication.class);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(userPrincipalManager.isTokenIssuedByAAD(TOKEN)).thenReturn(true);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        final FilterChain filterChain = (request, response) -> {
+            final SecurityContext context = SecurityContextHolder.getContext();
+            assertNotNull(context);
+            assertNotNull(context.getAuthentication());
+            SecurityContextHolder.clearContext();
+        };
+
+        filter.doFilterInternal(request, response, filterChain);
+        verify(userPrincipalManager, times(0)).buildUserPrincipal(TOKEN);
     }
 
 }


### PR DESCRIPTION
## Summary
<!--Describe the change briefly-->
When `AADAuthenticationFilter` or `AADAppRoleStatelessAuthenticationFilter` is auto-configured it will take action on every bearer token. This PR will skip the processing when the current context is already authenticated or the token is not issued by Azure AD.

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - active directory spring boot starter

## Additional Information