### PR TITLE
upgrade jms underlying library with azure-servicebus-jms-0.0.1

### DIFF
--- a/azure-spring-boot-parent/pom.xml
+++ b/azure-spring-boot-parent/pom.xml
@@ -33,8 +33,8 @@
         <mockito.core.version>2.8.9</mockito.core.version>
         <wiremock-standalone.version>2.19.0</wiremock-standalone.version>
         <commons-io.version>2.3</commons-io.version>
-        <qpid-jms-client.version>0.43.0</qpid-jms-client.version>
         <junit-params.version>1.1.1</junit-params.version>
+        <azure-servicebus-jms.version>0.0.1</azure-servicebus-jms.version>
     </properties>
 
     <profiles>
@@ -106,12 +106,12 @@
                 <artifactId>wiremock-standalone</artifactId>
                 <version>${wiremock-standalone.version}</version>
             </dependency>
-            <!--Qpid-->
             <dependency>
-                <groupId>org.apache.qpid</groupId>
-                <artifactId>qpid-jms-client</artifactId>
-                <version>${qpid-jms-client.version}</version>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-servicebus-jms</artifactId>
+                <version>${azure-servicebus-jms.version}</version>
             </dependency>
+
             <!-- TEST -->
             <dependency>
                 <groupId>pl.pragmatists</groupId>

--- a/azure-spring-boot-starters/azure-servicebus-jms-spring-boot-starter/pom.xml
+++ b/azure-spring-boot-starters/azure-servicebus-jms-spring-boot-starter/pom.xml
@@ -33,11 +33,9 @@
             <artifactId>spring-jms</artifactId>
         </dependency>
 
-        <!--Qpid-->
         <dependency>
-            <groupId>org.apache.qpid</groupId>
-            <artifactId>qpid-jms-client</artifactId>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-servicebus-jms</artifactId>
         </dependency>
-
     </dependencies>
 </project>

--- a/azure-spring-boot/pom.xml
+++ b/azure-spring-boot/pom.xml
@@ -149,6 +149,11 @@
             <artifactId>azure-client-authentication</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-servicebus-jms</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Micrometer metrics -->
         <dependency>
@@ -220,11 +225,5 @@
             <optional>true</optional>
         </dependency>
 
-        <!--Qpid-->
-        <dependency>
-            <groupId>org.apache.qpid</groupId>
-            <artifactId>qpid-jms-client</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 </project>

--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/jms/ServiceBusJMSAutoConfiguration.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/jms/ServiceBusJMSAutoConfiguration.java
@@ -6,7 +6,8 @@
 
 package com.microsoft.azure.spring.autoconfigure.jms;
 
-import org.apache.qpid.jms.JmsConnectionFactory;
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -22,7 +23,7 @@ import org.springframework.jms.core.JmsTemplate;
 import javax.jms.ConnectionFactory;
 
 @Configuration
-@ConditionalOnClass(JmsConnectionFactory.class)
+@ConditionalOnClass(ServiceBusJmsConnectionFactory.class)
 @ConditionalOnResource(resources = "classpath:servicebusjms.enable.config")
 @ConditionalOnProperty(value = "spring.jms.servicebus.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(AzureServiceBusJMSProperties.class)
@@ -34,21 +35,15 @@ public class ServiceBusJMSAutoConfiguration {
     @ConditionalOnMissingBean
     public ConnectionFactory jmsConnectionFactory(AzureServiceBusJMSProperties serviceBusJMSProperties) {
         final String connectionString = serviceBusJMSProperties.getConnectionString();
-        final String clientId = serviceBusJMSProperties.getTopicClientId();
-        final int idleTimeout = serviceBusJMSProperties.getIdleTimeout();
 
-        final ServiceBusKey serviceBusKey = ConnectionStringResolver.getServiceBusKey(connectionString);
-        final String host = serviceBusKey.getHost();
-        final String sasKeyName = serviceBusKey.getSharedAccessKeyName();
-        final String sasKey = serviceBusKey.getSharedAccessKey();
+        final long idleTimeout = serviceBusJMSProperties.getIdleTimeout();
 
-        final String remoteUri = String.format(AMQP_URI_FORMAT, host, idleTimeout);
-        final JmsConnectionFactory jmsConnectionFactory = new JmsConnectionFactory();
-        jmsConnectionFactory.setRemoteURI(remoteUri);
-        jmsConnectionFactory.setClientID(clientId);
-        jmsConnectionFactory.setUsername(sasKeyName);
-        jmsConnectionFactory.setPassword(sasKey);
-        return new CachingConnectionFactory(jmsConnectionFactory);
+        final ServiceBusJmsConnectionFactorySettings settings =
+                new ServiceBusJmsConnectionFactorySettings(idleTimeout, false);
+        final ServiceBusJmsConnectionFactory serviceBusJmsConnectionFactory =
+                new ServiceBusJmsConnectionFactory(connectionString, settings);
+
+        return new CachingConnectionFactory(serviceBusJmsConnectionFactory);
     }
 
     @Bean

--- a/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/jms/ServiceBusJMSAutoConfigurationTest.java
+++ b/azure-spring-boot/src/test/java/com/microsoft/azure/spring/autoconfigure/jms/ServiceBusJMSAutoConfigurationTest.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.azure.spring.autoconfigure.jms;
 
-import org.apache.qpid.jms.JmsConnectionFactory;
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -26,7 +26,7 @@ public class ServiceBusJMSAutoConfigurationTest {
 
     @Test
     public void testWithoutServiceBusJMSNamespace() {
-        this.contextRunner.withClassLoader(new FilteredClassLoader(JmsConnectionFactory.class))
+        this.contextRunner.withClassLoader(new FilteredClassLoader(ServiceBusJmsConnectionFactory.class))
                 .run(context -> assertThat(context).doesNotHaveBean(AzureServiceBusJMSProperties.class));
     }
 


### PR DESCRIPTION
Replace the underlying library of jms from org.apache.qpid: qpid-jms-client to com.microsoft.azure: azure-servicebus-jms