### PR TITLE
Sort lines.  Add link to storage starter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@
 
 ## Below are the new locations for Spring modules
 
-- [azure-keyvault-secrets-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-keyvault-secrets)
-- [azure-active-directory-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-active-directory) 
 - [azure-active-directory-b2c-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-active-directory-b2c)
+- [azure-active-directory-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-active-directory) 
 - [azure-cosmosdb-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-cosmosdb)
-- [spring-data-gremlin-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-data-gremlin)
+- [azure-keyvault-secrets-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-keyvault-secrets)
 - [azure-servicebus-jms-spring-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-servicebus-jms)
 - [azure-spring-boot-metrics-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-metrics)
+- [azure-spring-boot-starter-storage](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-storage)
+- [spring-data-gremlin-boot-starter](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/spring/azure-spring-boot-starter-data-gremlin)


### PR DESCRIPTION
Based on @jialindai 's comment on https://dev.azure.com/azure-spring-integration/spring-integration-private/_workitems/edit/254 we should add the spring boot storage starter.  I did not know we had one because I based my understanding on what are the available starters on this bullet list.