### PR TITLE
Fixes Bug #15333 - The exception message now matches the expected setting.

### DIFF
--- a/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/jms/AzureServiceBusJMSProperties.java
+++ b/azure-spring-boot/src/main/java/com/microsoft/azure/spring/autoconfigure/jms/AzureServiceBusJMSProperties.java
@@ -50,7 +50,7 @@ public class AzureServiceBusJMSProperties {
     public void validate() {
 
         if (!StringUtils.hasText(connectionString)) {
-            throw new IllegalArgumentException("'azure.servicebus.jms.connection-string' " +
+            throw new IllegalArgumentException("'spring.jms.servicebus.connection-string' " +
                     "should be provided");
         }
 


### PR DESCRIPTION
Applies to 2.1.x branch, and not to 2.2.x nor 2.3.x.

The error message for the exception did not match the expected setting name.

Fixes: #15333
